### PR TITLE
App 8756

### DIFF
--- a/.github/workflows/npm_package_release_npm.yaml
+++ b/.github/workflows/npm_package_release_npm.yaml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Deploy to NPM
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GH_TOKEN: ${{ secrets.AUTO_GITHUB_PAT_TOKEN }}
         run: npx auto shipit
 

--- a/.github/workflows/standard_spa_pr.yml
+++ b/.github/workflows/standard_spa_pr.yml
@@ -66,6 +66,7 @@ jobs:
         with:
           node-version: 16
           cache: "yarn"
+          registry-url: "https://registry.npmjs.org"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: yarn --frozen-lockfile --ignore-optional
@@ -102,6 +103,7 @@ jobs:
         with:
           node-version: 16
           cache: "yarn"
+          registry-url: "https://registry.npmjs.org"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: yarn --frozen-lockfile --ignore-optional
@@ -137,6 +139,7 @@ jobs:
         with:
           node-version: 16
           cache: "yarn"
+          registry-url: "https://registry.npmjs.org"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       # Only allow production deps be installed in the final build!


### PR DESCRIPTION
This fixes two more bugs. 

1. Yarn has its own registry and we need to use npmjs.org for our internal packages.
1. Auth shipit uses `NODE_AUTH_TOKEN` not `NPM_TOKEN`
