### PR TITLE
APP-9061 - let GH generate the npmrc

### DIFF
--- a/.github/workflows/npm_package_pr_npm.yaml
+++ b/.github/workflows/npm_package_pr_npm.yaml
@@ -41,9 +41,10 @@ jobs:
         with:
           node-version: 16
           cache: "npm"
-        env:
-          NODE_NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          registry-url: "https://registry.npmjs.org"
       - run: npm ci --ignore-scripts
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - run: npm run validate:ci
 
@@ -65,9 +66,10 @@ jobs:
         with:
           node-version: 16
           cache: "npm"
+          registry-url: "https://registry.npmjs.org"
       - run: npm ci --ignore-scripts
         env:
-          NODE_NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # Upload to chromatic
       - name: Publish to Chromatic

--- a/.github/workflows/npm_package_release_npm.yaml
+++ b/.github/workflows/npm_package_release_npm.yaml
@@ -39,12 +39,13 @@ jobs:
         with:
           node-version: 16
           cache: "npm"
-        env:
-          NODE_NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          registry-url: 'https://registry.npmjs.org'
       # Never install npm packages with build scrips!
       # This is an easy way for attackers to get read out the process.env
       # or inject code into the bundle
       - run: npm ci --ignore-scripts
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Validate
         run: npm run validate:ci
 
@@ -62,10 +63,11 @@ jobs:
         with:
           node-version: 16
           cache: "npm"
-        env:
-          NODE_NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          registry-url: 'https://registry.npmjs.org'
       # Only allow production deps be installed in the final build!
       - run: npm ci --ignore-scripts --omit=dev --omit=peer
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       # run the esbuild build scrips
       - run: npm rebuild esbuild
         if: ${{ inputs.use_esbuild }}
@@ -91,6 +93,7 @@ jobs:
   chromatic-deployment:
     runs-on: ${{ inputs.runs_on }}
     timeout-minutes: 15
+    if: ${{ inputs.use_chromatic }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -99,9 +102,10 @@ jobs:
         with:
           node-version: 16
           cache: "npm"
+          registry-url: 'https://registry.npmjs.org'
       - run: npm ci --ignore-scripts
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish to Chromatic
         uses: chromaui/action@v1


### PR DESCRIPTION
While debugging a deployment issue we found GH documentation explaining how to auto generate the .npmrc: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry.

This updates our npm PR and deployment scripts with this solution.