### PR TITLE
Update Chromatic settings

### DIFF
--- a/.github/workflows/npm_package_pr_npm.yaml
+++ b/.github/workflows/npm_package_pr_npm.yaml
@@ -78,3 +78,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           onlyChanged: true
+          exitOnceUploaded: true

--- a/.github/workflows/npm_package_release_npm.yaml
+++ b/.github/workflows/npm_package_release_npm.yaml
@@ -39,7 +39,7 @@ jobs:
         with:
           node-version: 16
           cache: "npm"
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
       # Never install npm packages with build scrips!
       # This is an easy way for attackers to get read out the process.env
       # or inject code into the bundle
@@ -63,7 +63,7 @@ jobs:
         with:
           node-version: 16
           cache: "npm"
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
       # Only allow production deps be installed in the final build!
       - run: npm ci --ignore-scripts --omit=dev --omit=peer
         env:
@@ -102,7 +102,7 @@ jobs:
         with:
           node-version: 16
           cache: "npm"
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
       - run: npm ci --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -114,3 +114,4 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           onlyChanged: true
           autoAcceptChanges: true
+          exitOnceUploaded: true

--- a/.github/workflows/standard_spa_pr.yml
+++ b/.github/workflows/standard_spa_pr.yml
@@ -114,6 +114,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           onlyChanged: true
+          exitOnceUploaded: true
 
   deploy_magic_url:
     name: Deploy Magic URL


### PR DESCRIPTION
Use `exitOnceUploaded: true` to release the runner during the VRT build time. Chromatic uses webhooks to let us know the state of these builds independently.