### PR TITLE
Update standard_spa_pr.yml

### DIFF
--- a/.github/workflows/standard_spa_pr.yml
+++ b/.github/workflows/standard_spa_pr.yml
@@ -166,4 +166,6 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Deploy
         # This bucket file location is static and editing it will break the Magic URL
-        run: aws s3 sync deploy/dist s3://${{ secrets.AWS_APPS_BUCKET }}/static/manual-deploy/${{ github.event.repository.name }}/PR-${{ github.event.number }}/
+        run: |
+          mv deploy/dist/${{ github.event.repository.name }}-remote-types.tgz deploy/dist/remote-types.tgz
+          aws s3 sync deploy/dist s3://${{ secrets.AWS_APPS_BUCKET }}/static/manual-deploy/${{ github.event.repository.name }}/PR-${{ github.event.number }}/


### PR DESCRIPTION
Rename repo-name remote types to just remote types on s3 upload.

This is a hot fix. The remote types file will be named correctly in later versions 