### PR TITLE
[No Ticket] - Better Magic URL action

### DIFF
--- a/.github/workflows/standard_spa_pr_NPM.yml
+++ b/.github/workflows/standard_spa_pr_NPM.yml
@@ -68,6 +68,10 @@ on:
         description: 'Used to determine which test to run'
         type: string
         default: 'cypress/e2e/**/*.feature'
+      magic_url_route: 
+        description: 'The relative route the magic url should go to'
+        type: string
+        default: ''
     secrets:
       NPM_TOKEN:
         description: "A J1 npm.com Publish token"
@@ -206,6 +210,23 @@ jobs:
         run: |
           [ -f deploy/dist/${{ github.event.repository.name }}-remote-types.tgz ] && mv deploy/dist/${{ github.event.repository.name }}-remote-types.tgz deploy/dist/remote-types.tgz
           aws s3 sync deploy/dist s3://${{ secrets.AWS_APPS_BUCKET }}/static/manual-deploy/${{ github.event.repository.name }}/PR-${{ github.event.number }}/
+
+  magic_url:
+    name: Post Magic URL
+    runs-on: ${{ inputs.runs_on }}
+    timeout-minutes: 1
+    if: ${{ inputs.use_magic_url }}
+    needs: deploy_magic_url
+    steps:
+      - name: Return Magic URL
+        uses: Sibz/github-status-action@v1
+        with: 
+          authToken: ${{ secrets.GITHUB_TOKEN }}
+          state: 'success'
+          context: 'Magic URL'
+          description: "Use the 'Details' link to view this PR in dev"
+          target_url: https://apps.dev.jupiterone.io/${{ inputs.magic_url_route }}?magic=%7B%${{ github.event.repository.name }}%22:%22PR-${{ github.event.pull_request.number }}%22%7D
+          sha: ${{github.event.pull_request.head.sha || github.sha}}
 
   prepare_for_e2e_test:
     defaults:


### PR DESCRIPTION
Based on the findings from our E2E work, we finally have a better solution to the Magic URL publish. This adds the URL to the GitHub check instead of having to run a job in every Repo to post a comment.