### PR TITLE
cypress-specific-runs-on

### DIFF
--- a/.github/workflows/standard_spa_pr.yml
+++ b/.github/workflows/standard_spa_pr.yml
@@ -11,9 +11,10 @@ on:
       runs_on:
         description: "What github runner should be used (e.g. jupiterone-dev)"
         type: string
-      runs_on_default:
-        default: "['jupiterone-dev', 'amd64']"
-        type: string
+      use_github_runner:
+        description: "If true will levarege ubuntu-latest, otherwise will fall back to the J1 in-house runner"
+        default: false
+        type: boolean
       install_yarn:
         description: "In house runners may not have yarn installed"
         required: false
@@ -108,7 +109,7 @@ jobs:
       run:
         working-directory: ${{ inputs.working_directory }}
     name: Creates shared variables used by the the jobs below based on whether the jobs were triggered by another repo or internally
-    runs-on: ${{ inputs.runs_on || fromJson(inputs.runs_on_default) }}
+    runs-on: ${{ inputs.use_github_runner && 'ubuntu-latest' || '["jupiterone-dev", "arm64"]' }}
     timeout-minutes: 15
     outputs:
       groupId: ${{ steps.outputStep.outputs.groupId }}
@@ -129,7 +130,7 @@ jobs:
       run:
         working-directory: ${{ inputs.working_directory }}
     name: Validate
-    runs-on: ${{ inputs.runs_on || fromJson(inputs.runs_on_default) }}
+    runs-on: ${{ inputs.use_github_runner && 'ubuntu-latest' || '["jupiterone-dev", "arm64"]' }}
     timeout-minutes: 15
     concurrency:
       group: validate-${{ needs.create-shared-vars.outputs.groupId }}
@@ -181,7 +182,7 @@ jobs:
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}
-    runs-on: ${{ inputs.runs_on || fromJson(inputs.runs_on_default) }}
+    runs-on: ${{ inputs.use_github_runner && 'ubuntu-latest' || '["jupiterone-dev", "arm64"]' }}
     timeout-minutes: 15
     concurrency:
       group: chromatic-deployment-${{ needs.create-shared-vars.outputs.groupId }}
@@ -223,7 +224,7 @@ jobs:
       run:
         working-directory: ${{ inputs.working_directory }}
     name: Deploy Magic URL
-    runs-on: ${{ inputs.runs_on || fromJson(inputs.runs_on_default) }}
+    runs-on: ${{ inputs.use_github_runner && 'ubuntu-latest' || '["jupiterone-dev", "arm64"]' }}
     timeout-minutes: 15
     concurrency:
       group: deploy-magic-url-${{ needs.create-shared-vars.outputs.groupId }}
@@ -274,7 +275,7 @@ jobs:
       run:
         working-directory: ${{ inputs.working_directory }}
     name: Prepare For E2E Tests
-    runs-on: ${{ inputs.runs_on || fromJson(inputs.runs_on_default) }}
+    runs-on: ${{ inputs.use_github_runner && 'ubuntu-latest' || '["jupiterone-dev", "arm64"]' }}
     timeout-minutes: 15
     concurrency:
       group: prepare-for-e2e-test-${{ needs.create-shared-vars.outputs.groupId }}
@@ -319,7 +320,7 @@ jobs:
       run:
         working-directory: ${{ inputs.working_directory }}
     name: Run E2E Tests for ${{ needs.create-shared-vars.outputs.e2eJobDescription }}
-    runs-on: ${{ inputs.runs_on || fromJson(inputs.runs_on_default) }}
+    runs-on: ${{ inputs.use_github_runner && 'ubuntu-latest' || '["jupiterone-dev", "amd64"]' }}
     container:
       image: cypress/browsers:node18.12.0-chrome106-ff106
       options: --platform linux/amd64 --privileged
@@ -421,7 +422,7 @@ jobs:
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}
-    runs-on: ${{ inputs.runs_on || fromJson(inputs.runs_on_default) }}
+    runs-on: ${{ inputs.use_github_runner && 'ubuntu-latest' || '["jupiterone-dev", "arm64"]' }}
     timeout-minutes: 60
     concurrency:
       group: validate-${{ needs.create-shared-vars.outputs.groupId }}

--- a/.github/workflows/standard_spa_pr.yml
+++ b/.github/workflows/standard_spa_pr.yml
@@ -9,7 +9,7 @@ on:
         type: string
         default: '.'
       runs_on:
-        description: "What github runner should be used (e.g. jupiterone-dev)"
+        description: "Deprecated noop - To be removed"
         type: string
       use_github_runner:
         description: "If true will levarege ubuntu-latest, otherwise will fall back to the J1 in-house runner"

--- a/.github/workflows/standard_spa_pr_NPM.yml
+++ b/.github/workflows/standard_spa_pr_NPM.yml
@@ -10,9 +10,12 @@ on:
         type: string
         default: '.'
       runs_on:
-        description: "What github runner should be used (e.g. jupiterone-dev)"
-        default: "['jupiterone-dev', 'arm64']"
+        description: "Deprecated noop - To be removed"
         type: string
+      use_github_runner:
+        description: "If true will levarege ubuntu-latest, otherwise will fall back to the J1 in-house runner"
+        default: false
+        type: boolean
       use_validate:
         description: "Run test, in most case we want this"
         required: true
@@ -107,7 +110,7 @@ jobs:
       run:
         working-directory: ${{ inputs.working_directory }}
     name: Creates shared variables used by the the jobs below based on whether the jobs were triggered by another repo or internally
-    runs-on: ${{ fromJson(inputs.runs_on) }}
+    runs-on: ${{ inputs.use_github_runner && 'ubuntu-latest' || '["jupiterone-dev", "arm64"]' }}
     timeout-minutes: 15
     outputs:
       groupId: ${{ steps.outputStep.outputs.groupId }}
@@ -128,7 +131,7 @@ jobs:
       run:
         working-directory: ${{ inputs.working_directory }}
     name: Validate
-    runs-on: ${{ fromJson(inputs.runs_on) }}
+    runs-on: ${{ inputs.use_github_runner && 'ubuntu-latest' || '["jupiterone-dev", "arm64"]' }}
     timeout-minutes: 15
     concurrency:
       group: validate-${{ needs.create-shared-vars.outputs.groupId }}
@@ -171,7 +174,7 @@ jobs:
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}
-    runs-on: ${{ fromJson(inputs.runs_on) }}
+    runs-on: ${{ inputs.use_github_runner && 'ubuntu-latest' || '["jupiterone-dev", "arm64"]' }}
     timeout-minutes: 15
     concurrency:
       group: chromatic-deployment-${{ needs.create-shared-vars.outputs.groupId }}
@@ -204,7 +207,7 @@ jobs:
       run:
         working-directory: ${{ inputs.working_directory }}
     name: Deploy Magic URL
-    runs-on: ${{ fromJson(inputs.runs_on) }}
+    runs-on: ${{ inputs.use_github_runner && 'ubuntu-latest' || '["jupiterone-dev", "arm64"]' }}
     timeout-minutes: 15
     concurrency:
       group: deploy-magic-url-${{ needs.create-shared-vars.outputs.groupId }}
@@ -243,7 +246,7 @@ jobs:
 
   magic_url:
     name: Post Magic URL
-    runs-on: ${{ fromJson(inputs.runs_on) }}
+    runs-on: ${{ inputs.use_github_runner && 'ubuntu-latest' || '["jupiterone-dev", "arm64"]' }}
     timeout-minutes: 1
     concurrency:
       group: magic-url-${{ needs.create-shared-vars.outputs.groupId }}
@@ -266,7 +269,7 @@ jobs:
       run:
         working-directory: ${{ inputs.working_directory }}
     name: Prepare For E2E Tests
-    runs-on: ${{ fromJson(inputs.runs_on) }}
+    runs-on: ${{ inputs.use_github_runner && 'ubuntu-latest' || '["jupiterone-dev", "arm64"]' }}
     timeout-minutes: 15
     concurrency:
       group: prepare-for-e2e-test-${{ needs.create-shared-vars.outputs.groupId }}
@@ -311,7 +314,7 @@ jobs:
       run:
         working-directory: ${{ inputs.working_directory }}
     name: Run E2E Tests for ${{ needs.create-shared-vars.outputs.e2eJobDescription }}
-    runs-on: "['jupiterone-dev', 'amd64']"
+    runs-on: ${{ inputs.use_github_runner && 'ubuntu-latest' || '["jupiterone-dev", "amd64"]' }}
     container:
       image: cypress/browsers:node18.12.0-chrome106-ff106
       options: --platform linux/amd64 --privileged
@@ -413,7 +416,7 @@ jobs:
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}
-    runs-on: ${{ fromJson(inputs.runs_on) }}
+    runs-on: ${{ inputs.use_github_runner && 'ubuntu-latest' || '["jupiterone-dev", "arm64"]' }}
     timeout-minutes: 60
     concurrency:
       group: validate-${{ needs.create-shared-vars.outputs.groupId }}

--- a/.github/workflows/standard_spa_pr_NPM.yml
+++ b/.github/workflows/standard_spa_pr_NPM.yml
@@ -11,9 +11,7 @@ on:
         default: '.'
       runs_on:
         description: "What github runner should be used (e.g. jupiterone-dev)"
-        type: string
-      runs_on_default:
-        default: "['jupiterone-dev', 'amd64']"
+        default: "['jupiterone-dev', 'arm64']"
         type: string
       use_validate:
         description: "Run test, in most case we want this"
@@ -109,7 +107,7 @@ jobs:
       run:
         working-directory: ${{ inputs.working_directory }}
     name: Creates shared variables used by the the jobs below based on whether the jobs were triggered by another repo or internally
-    runs-on: ${{ inputs.runs_on || fromJson(inputs.runs_on_default) }}
+    runs-on: ${{ fromJson(inputs.runs_on) }}
     timeout-minutes: 15
     outputs:
       groupId: ${{ steps.outputStep.outputs.groupId }}
@@ -130,7 +128,7 @@ jobs:
       run:
         working-directory: ${{ inputs.working_directory }}
     name: Validate
-    runs-on: ${{ inputs.runs_on || fromJson(inputs.runs_on_default) }}
+    runs-on: ${{ fromJson(inputs.runs_on) }}
     timeout-minutes: 15
     concurrency:
       group: validate-${{ needs.create-shared-vars.outputs.groupId }}
@@ -173,7 +171,7 @@ jobs:
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}
-    runs-on: ${{ inputs.runs_on || fromJson(inputs.runs_on_default) }}
+    runs-on: ${{ fromJson(inputs.runs_on) }}
     timeout-minutes: 15
     concurrency:
       group: chromatic-deployment-${{ needs.create-shared-vars.outputs.groupId }}
@@ -206,7 +204,7 @@ jobs:
       run:
         working-directory: ${{ inputs.working_directory }}
     name: Deploy Magic URL
-    runs-on: ${{ inputs.runs_on || fromJson(inputs.runs_on_default) }}
+    runs-on: ${{ fromJson(inputs.runs_on) }}
     timeout-minutes: 15
     concurrency:
       group: deploy-magic-url-${{ needs.create-shared-vars.outputs.groupId }}
@@ -245,7 +243,7 @@ jobs:
 
   magic_url:
     name: Post Magic URL
-    runs-on: ${{ inputs.runs_on || fromJson(inputs.runs_on_default) }}
+    runs-on: ${{ fromJson(inputs.runs_on) }}
     timeout-minutes: 1
     concurrency:
       group: magic-url-${{ needs.create-shared-vars.outputs.groupId }}
@@ -268,7 +266,7 @@ jobs:
       run:
         working-directory: ${{ inputs.working_directory }}
     name: Prepare For E2E Tests
-    runs-on: ${{ inputs.runs_on || fromJson(inputs.runs_on_default) }}
+    runs-on: ${{ fromJson(inputs.runs_on) }}
     timeout-minutes: 15
     concurrency:
       group: prepare-for-e2e-test-${{ needs.create-shared-vars.outputs.groupId }}
@@ -313,7 +311,7 @@ jobs:
       run:
         working-directory: ${{ inputs.working_directory }}
     name: Run E2E Tests for ${{ needs.create-shared-vars.outputs.e2eJobDescription }}
-    runs-on: ${{ inputs.runs_on || fromJson(inputs.runs_on_default) }}
+    runs-on: "['jupiterone-dev', 'amd64']"
     container:
       image: cypress/browsers:node18.12.0-chrome106-ff106
       options: --platform linux/amd64 --privileged
@@ -415,7 +413,7 @@ jobs:
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}
-    runs-on: ${{ inputs.runs_on || fromJson(inputs.runs_on_default) }}
+    runs-on: ${{ fromJson(inputs.runs_on) }}
     timeout-minutes: 60
     concurrency:
       group: validate-${{ needs.create-shared-vars.outputs.groupId }}


### PR DESCRIPTION
Per our conversation with @ryanmcafee, this sets our default runner to `'["jupiterone-dev", "arm64"]'` for every job except the Cypress one which defaults to `'["jupiterone-dev", "amd64"]' `. We also have a boolean input called `use_github_runner` that will allow them to set the runner to ubuntu-latest if it's needed for some reason (as a fallback option). 