### PR TITLE
e2e-multiple-users

### DIFF
--- a/.github/workflows/standard_spa_pr_NPM.yml
+++ b/.github/workflows/standard_spa_pr_NPM.yml
@@ -327,7 +327,7 @@ jobs:
         id: updateArtemisConfig
         run: npx update-artemis-config --pathToArtemisConfig=${{ inputs.e2e_artemis_config_path }} --usersCount=${{ needs.create-shared-vars.outputs.usersCount }}
         continue-on-error: true
-      - name: launch artemis (new flow)
+      - name: launch artemis
         if: steps.updateArtemisConfig.outcome == 'success'
         run: npx artemis-launch -c tmp/artemis-config-updated.yaml --action=launch --outputFilename=artemis-run
       # TODO: Remove via APP-11658
@@ -429,7 +429,6 @@ jobs:
           SPEC: ${{ inputs.spec_to_run }}
           ACCOUNT: ${{ needs.prepare_for_e2e_test.outputs.artemisAccountName }}
           ACCOUNT_ID: ${{ needs.prepare_for_e2e_test.outputs.artemisAccountId }}
-          # TODO: Remove via APP-11658
           USERS: ${{ needs.prepare_for_e2e_test.outputs.artemisUsers }}
           TAGS: ${{ inputs.e2e_filter_tags }}
       # We have to manually output an exit code of 0 to ensure the action passes if e2e_pass_on_error is true

--- a/.github/workflows/standard_spa_pr_NPM.yml
+++ b/.github/workflows/standard_spa_pr_NPM.yml
@@ -306,7 +306,7 @@ jobs:
       artemisAccountId: ${{ steps.outputStep.outputs.artemisAccountId }}
       # compact JSON of [{csrf:string,secret:string,subject:string},...]
       artemisUsers: ${{ steps.outputStep.outputs.artemisUsers }}
-      # TODO: Remove legacy when repos are updated to new schema
+      # TODO: Remove via APP-11658
       artemisUsersLegacy: ${{ steps.outputStep.outputs.artemisUsersLegacy }}
     steps:
       - uses: actions/checkout@v3
@@ -419,7 +419,7 @@ jobs:
           SPEC: ${{ inputs.spec_to_run }}
           ACCOUNT: ${{ needs.prepare_for_e2e_test.outputs.artemisAccountName }}
           ACCOUNT_ID: ${{ needs.prepare_for_e2e_test.outputs.artemisAccountId }}
-          # TODO: Remove legacy when repos are updated to new schema
+          # TODO: Remove via APP-11658
           USERS: ${{ needs.prepare_for_e2e_test.outputs.artemisUsers || needs.prepare_for_e2e_test.outputs.artemisUsersLegacy }}
           TAGS: ${{ inputs.e2e_filter_tags }}
       # We have to manually output an exit code of 0 to ensure the action passes if e2e_pass_on_error is true

--- a/.github/workflows/standard_spa_pr_NPM.yml
+++ b/.github/workflows/standard_spa_pr_NPM.yml
@@ -129,17 +129,21 @@ jobs:
     runs-on: ${{ inputs.use_github_runner && inputs.github_runner || fromJson(inputs.default_runner) }}
     timeout-minutes: 15
     outputs:
-      groupId: ${{ steps.outputStep.outputs.groupId }}
-      e2eJobDescription: ${{ steps.outputStep.outputs.e2eJobDescription }}
+      groupId: ${{ steps.externalTrigger.outputs.groupId }}
+      e2eJobDescription: ${{ steps.externalTrigger.outputs.e2eJobDescription }}
+      usersCount: ${{ steps.userCount.outputs.usersCount }}
     steps:
-      - id: outputStep
+      - id: userCount
+        run: |
+          echo "usersCount=$(echo '${{ inputs.e2e_containers }}' | jq '. | length')" >> $GITHUB_OUTPUT
+      - id: externalTrigger
         run: |
           if [[ ${{ inputs.externally_triggered }} == true ]]; then
             echo "groupId=$(date +'%Y-%m-%d %H:%M:%S %s')" >> $GITHUB_OUTPUT
             echo "e2eJobDescription=external repo ${{ inputs.external_pr_repo_name }} - ${{ inputs.external_pr_branch }}" >> $GITHUB_OUTPUT 
           else
             echo "groupId=${{ github.workflow }}-${{ github.event.repository.name }}-${{ github.event.pull_request.number || github.ref }}" >> $GITHUB_OUTPUT
-            echo "e2eJobDescription=${{ github.event.repository.name }}" >> $GITHUB_OUTPUT         
+            echo "e2eJobDescription=${{ github.event.repository.name }}" >> $GITHUB_OUTPUT
           fi
 
   validate:
@@ -302,6 +306,8 @@ jobs:
       artemisAccountId: ${{ steps.outputStep.outputs.artemisAccountId }}
       # compact JSON of [{csrf:string,secret:string,subject:string},...]
       artemisUsers: ${{ steps.outputStep.outputs.artemisUsers }}
+      # TODO: Remove legacy when repos are updated to new schema
+      artemisUsersLegacy: ${{ steps.outputStep.outputs.artemisUsersLegacy }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -319,14 +325,20 @@ jobs:
           role-session-name:
             ${{ github.event.repository.name }}-magic-url-role-session
           aws-region: us-east-1
+      - name: update artemis config
+        run: npx update-artemis-config --pathToArtemisConfig=${{ inputs.e2e_artemis_config_path }} --usersCount=${{ needs.create-shared-vars.outputs.usersCount }}
       - name: launch artemis
-        run: npx artemis-launch -c ${{ inputs.e2e_artemis_config_path }} --action=launch --outputFilename=artemis-run
+        run: npx artemis-launch -c tmp/artemis-config-updated.yaml --action=launch --outputFilename=artemis-run
       - id: outputStep
         # Use jq to extract the accountId and user sessions from the json file in a raw form
         run: |
           echo "artemisAccountName=$(jq -r .[0].metadata.accountName < artemis-run.json)" >> $GITHUB_OUTPUT
           echo "artemisAccountId=$(jq -r .[0].id < artemis-run.json)" >> $GITHUB_OUTPUT
-          echo "artemisUsers=$(jq -c 'map((select(. | .metadata.type == "user-session")) | { secret: .metadata.secret, csrf: .metadata.csrf, subject: .metadata.subject })' < artemis-run.json)" >> $GITHUB_OUTPUT
+          echo "artemisUsers=$(jq -c 'map((select(. | .type == "User")) | { tokenSecret: .metadata.token.tokenSecret, tokenCsrf: .metadata.token.tokenCsrf, groupName: .metadata.groupName })' < artemis-run.json)" >> $GITHUB_OUTPUT
+      # TODO: Remove legacy when repos are updated to new schema
+      - id: outputStepLegacy
+        run: |
+          echo "artemisUsersLegacy=$(jq -c 'map((select(. | .metadata.type == "user-session")) | { secret: .metadata.secret, csrf: .metadata.csrf, subject: .metadata.subject })' < artemis-run.json)" >> $GITHUB_OUTPUT
 
   # Kicks off tests this repo
   run-e2e-tests:
@@ -352,7 +364,7 @@ jobs:
       # when one test fails, DO NOT cancel the other
       # containers, because this will kill Cypress processes
       # leaving Cypress Cloud hanging ...
-      # https://github.com/cypress-io/github-action/issues/48
+      # https://github.com/cypress-io/github-action/issues/48 
       fail-fast: false
       matrix:
         # run copies of the current job in parallel
@@ -360,7 +372,7 @@ jobs:
         node: [18]
     steps:
       - name: Log E2E Info
-        run: echo "Running E2E test for PR with title of ${{ inputs.external_pr_title || github.event.pull_request.title }} and number being ${{ inputs.external_pr_number || github.event.pull_request.number }}. The following account will be used ${{ needs.prepare_for_e2e_test.outputs.artemisAccountName }} (${{ needs.prepare_for_e2e_test.outputs.artemisAccountId }})."
+        run: echo "Running E2E test for PR with title of ${{ inputs.external_pr_title || github.event.pull_request.title }} and number being ${{ inputs.external_pr_number || github.event.pull_request.number }}. The following account will be used ${{ needs.prepare_for_e2e_test.outputs.artemisAccountName }} (${{ needs.prepare_for_e2e_test.outputs.artemisAccountId }}). The following matrix container is being used ${{ matrix.containers }}"
       - name: Log groupId
         run: echo "groupId - ${{ needs.create-shared-vars.outputs.groupId }}"
       - name: Log status of prepare_for_e2e_test job
@@ -397,6 +409,7 @@ jobs:
           COMMIT_INFO_BRANCH: ${{ inputs.external_pr_branch }}
           COMMIT_INFO_AUTHOR: ${{ inputs.external_pr_author }}
           COMMIT_INFO_SHA: ${{ inputs.external_pr_sha }}
+          CYPRESS_CONTAINER: ${{ matrix.containers }}
           CYPRESS_MAILINATOR_API_KEY: ${{ secrets.CYPRESS_MAILINATOR_API_KEY }}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           CYPRESS_PROJECT_ID: ${{ secrets.CYPRESS_PROJECT_ID }}
@@ -409,7 +422,8 @@ jobs:
           SPEC: ${{ inputs.spec_to_run }}
           ACCOUNT: ${{ needs.prepare_for_e2e_test.outputs.artemisAccountName }}
           ACCOUNT_ID: ${{ needs.prepare_for_e2e_test.outputs.artemisAccountId }}
-          USERS: ${{ needs.prepare_for_e2e_test.outputs.artemisUsers }}
+          # TODO: Remove legacy when repos are updated to new schema
+          USERS: ${{ needs.prepare_for_e2e_test.outputs.artemisUsers || needs.prepare_for_e2e_test.outputs.artemisUsersLegacy }}
           TAGS: ${{ inputs.e2e_filter_tags }}
       # We have to manually output an exit code of 0 to ensure the action passes if e2e_pass_on_error is true
       - name: Pass with failures

--- a/.github/workflows/standard_spa_pr_NPM.yml
+++ b/.github/workflows/standard_spa_pr_NPM.yml
@@ -302,12 +302,10 @@ jobs:
       contents: read
       pull-requests: write
     outputs:
-      artemisAccountName: ${{ steps.outputStep.outputs.artemisAccountName }}
-      artemisAccountId: ${{ steps.outputStep.outputs.artemisAccountId }}
+      artemisAccountName: ${{ steps.accountInfo.outputs.artemisAccountName }}
+      artemisAccountId: ${{ steps.accountInfo.outputs.artemisAccountId }}
       # compact JSON of [{csrf:string,secret:string,subject:string},...]
-      artemisUsers: ${{ steps.outputStep.outputs.artemisUsers }}
-      # TODO: Remove via APP-11658
-      artemisUsersLegacy: ${{ steps.outputStep.outputs.artemisUsersLegacy }}
+      artemisUsers: ${{ steps.userInfo.outputs.artemisUsers }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -326,16 +324,28 @@ jobs:
             ${{ github.event.repository.name }}-magic-url-role-session
           aws-region: us-east-1
       - name: update artemis config
+        id: updateArtemisConfig
         run: npx update-artemis-config --pathToArtemisConfig=${{ inputs.e2e_artemis_config_path }} --usersCount=${{ needs.create-shared-vars.outputs.usersCount }}
-      - name: launch artemis
+        continue-on-error: true
+      - name: launch artemis (new flow)
+        if: steps.updateArtemisConfig.outcome == 'success'
         run: npx artemis-launch -c tmp/artemis-config-updated.yaml --action=launch --outputFilename=artemis-run
-      - id: outputStep
+      # TODO: Remove via APP-11658
+      - name: launch artemis (legacy flow)
+        if: steps.updateArtemisConfig.outcome != 'success'
+        run: npx artemis-launch -c ${{ inputs.e2e_artemis_config_path }} --action=launch --outputFilename=artemis-run
+      - id: accountInfo
         # Use jq to extract the accountId and user sessions from the json file in a raw form
         run: |
           echo "artemisAccountName=$(jq -r .[0].metadata.accountName < artemis-run.json)" >> $GITHUB_OUTPUT
           echo "artemisAccountId=$(jq -r .[0].id < artemis-run.json)" >> $GITHUB_OUTPUT
-          echo "artemisUsers=$(jq -c 'map((select(. | .type == "User")) | { tokenSecret: .metadata.token.tokenSecret, tokenCsrf: .metadata.token.tokenCsrf, groupName: .metadata.groupName })' < artemis-run.json)" >> $GITHUB_OUTPUT
-          echo "artemisUsersLegacy=$(jq -c 'map((select(. | .metadata.type == "user-session")) | { secret: .metadata.secret, csrf: .metadata.csrf, subject: .metadata.subject })' < artemis-run.json)" >> $GITHUB_OUTPUT
+      - id: userInfo
+        run: |
+          if [[ ${{ steps.updateArtemisConfig.outcome }} == 'success' ]]; then
+            echo "artemisUsers=$(jq -c 'map((select(. | .type == "User")) | { tokenSecret: .metadata.token.tokenSecret, tokenCsrf: .metadata.token.tokenCsrf, groupName: .metadata.groupName })' < artemis-run.json)" >> $GITHUB_OUTPUT
+          else
+            echo "artemisUsers=$(jq -c 'map((select(. | .metadata.type == "user-session")) | { secret: .metadata.secret, csrf: .metadata.csrf, subject: .metadata.subject })' < artemis-run.json)" >> $GITHUB_OUTPUT
+          fi
 
   # Kicks off tests this repo
   run-e2e-tests:
@@ -420,7 +430,7 @@ jobs:
           ACCOUNT: ${{ needs.prepare_for_e2e_test.outputs.artemisAccountName }}
           ACCOUNT_ID: ${{ needs.prepare_for_e2e_test.outputs.artemisAccountId }}
           # TODO: Remove via APP-11658
-          USERS: ${{ needs.prepare_for_e2e_test.outputs.artemisUsers || needs.prepare_for_e2e_test.outputs.artemisUsersLegacy }}
+          USERS: ${{ needs.prepare_for_e2e_test.outputs.artemisUsers }}
           TAGS: ${{ inputs.e2e_filter_tags }}
       # We have to manually output an exit code of 0 to ensure the action passes if e2e_pass_on_error is true
       - name: Pass with failures

--- a/.github/workflows/standard_spa_pr_NPM.yml
+++ b/.github/workflows/standard_spa_pr_NPM.yml
@@ -335,9 +335,6 @@ jobs:
           echo "artemisAccountName=$(jq -r .[0].metadata.accountName < artemis-run.json)" >> $GITHUB_OUTPUT
           echo "artemisAccountId=$(jq -r .[0].id < artemis-run.json)" >> $GITHUB_OUTPUT
           echo "artemisUsers=$(jq -c 'map((select(. | .type == "User")) | { tokenSecret: .metadata.token.tokenSecret, tokenCsrf: .metadata.token.tokenCsrf, groupName: .metadata.groupName })' < artemis-run.json)" >> $GITHUB_OUTPUT
-      # TODO: Remove legacy when repos are updated to new schema
-      - id: outputStepLegacy
-        run: |
           echo "artemisUsersLegacy=$(jq -c 'map((select(. | .metadata.type == "user-session")) | { secret: .metadata.secret, csrf: .metadata.csrf, subject: .metadata.subject })' < artemis-run.json)" >> $GITHUB_OUTPUT
 
   # Kicks off tests this repo
@@ -351,9 +348,6 @@ jobs:
       image: cypress/browsers:node18.12.0-chrome106-ff106
       options: --platform linux/amd64 --privileged
     timeout-minutes: 15
-    concurrency:
-      group: run-e2e-tests-${{ needs.create-shared-vars.outputs.groupId }}
-      cancel-in-progress: true
     if: |
       always()
       && !cancelled()
@@ -370,6 +364,9 @@ jobs:
         # run copies of the current job in parallel
         containers: ${{ fromJson(inputs.e2e_containers) }}
         node: [18]
+    concurrency:
+      group: run-e2e-tests-${{ needs.create-shared-vars.outputs.groupId }}-${{ matrix.containers }}
+      cancel-in-progress: true
     steps:
       - name: Log E2E Info
         run: echo "Running E2E test for PR with title of ${{ inputs.external_pr_title || github.event.pull_request.title }} and number being ${{ inputs.external_pr_number || github.event.pull_request.number }}. The following account will be used ${{ needs.prepare_for_e2e_test.outputs.artemisAccountName }} (${{ needs.prepare_for_e2e_test.outputs.artemisAccountId }}). The following matrix container is being used ${{ matrix.containers }}"


### PR DESCRIPTION
Currently our E2E flow assumes one account is used when logging in and running tests. This updated flow allows for multiple users, enabling users with different permission types as well as scaling the number of Cypress containers running.

I made sure to make this is backwards compatible. The bump to Artemis 4+ (that occurs in web-tools-e2e) changes the output, so I needed to ensure this wouldn't break pre-existing setups.