### PR TITLE
Make remote type check mandatory

### DIFF
--- a/.github/workflows/standard_spa_pr_NPM.yml
+++ b/.github/workflows/standard_spa_pr_NPM.yml
@@ -182,12 +182,8 @@ jobs:
       # Validate runtime types (if applicable)
       - name: Validate Runtime Modules Types
         run: |
-          if [[ -f "node_modules/@jupiterone/web-runtime-modules/cli/testInterfaceRuntimeModules.js" ]]; then
-            npx testInterfaceRuntimeModules;
-            echo "No breaking changes found";
-          else
-            echo "Skipping, @jupiterone/web-runtime-modules not installed";
-          fi
+          npx -p @jupiterone/web-runtime-modules testInterfaceRuntimeModules;
+          echo "No breaking changes found";
         if: ${{ !env.HAS_SKIP }}
 
   chromatic-deployment:


### PR DESCRIPTION
This uses npx to ensure we always test the remote types, even of the project does not have the package installed.

This is in keeping with how we now do it in Jenkins during deploy