### PR TITLE
Create additional workflow

### DIFF
--- a/.github/workflows/publish_to_docker_registries.yaml
+++ b/.github/workflows/publish_to_docker_registries.yaml
@@ -1,0 +1,102 @@
+name: Publish image to Docker and GHCR
+
+on:
+  workflow_call:
+    inputs:
+      runs_on:
+        description: "What Github runner should be used (defaults to ubuntu-latest)"
+        type: string
+        required: false
+        default: "ubuntu-latest"
+      package-name:
+        description: "Name of package to publish to Docker Hub"
+        required: true
+        type: string
+      push-to-registry:
+        description:
+          "Determines if the built image should be pushed to the registry (will
+          only push on a merge by default)"
+        required: false
+        default: ${{github.event_name != 'pull_request'}}
+        type: boolean
+      docker-context:
+        description: "The Docker context to use when building the image"
+        required: false
+        default: .
+        type: string
+      build-platforms:
+        description: "The platforms to build Docker images for"
+        required: false
+        default: "linux/amd64,linux/arm64"
+        type: string
+      publish-to-docker:
+        description: "Should the image be published to DockerHub"
+        required: false
+        default: true
+        type: boolean
+      publish-to-ghcr:
+        description: "Should the image be published to GHCR"
+        required: false
+        default: true
+        type: boolean
+    secrets:
+      DOCKER_USERNAME:
+        description: "Docker username to authenticate and publish with"
+        required: true
+      DOCKER_PASSWORD:
+        description: "Docker password to authenticate and publish with"
+        required: true
+      GHCR_USERNAME:
+        description: "GHCR Username to authenticate and publish with"
+        required: true
+      GHCR_PASSWORD:
+        description: "GHCR password to authenticate and publish with"
+        required: true
+jobs:
+  build-image:
+    name: build image
+    runs-on: ${{ inputs.runs_on }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            name=docker.io/${{ inputs.package-name }},enable=${{ inputs.publish-to-docker }}
+            name=ghcr.io/${{ inputs.package-name }},enable=${{ inputs.publish-to-ghcr }}
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        if: inputs.publish-to-docker
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        if: inputs.publish-to-ghcr
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_USERNAME }}
+          password: ${{ secrets.GHCR_PASSWORD }}
+      - name: Build and publish
+        uses: docker/build-push-action@v3
+        with:
+          context: ${{ inputs.docker-context }}
+          platforms: ${{ inputs.build-platforms }}
+          push: ${{ inputs.push-to-registry == true }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Clone the publish_docker_ghcr.yaml workflow, in preparation for renaming/deprecating it. This is useful since it doesn't tie this workflow name to specific Docker registries, allowing us to change them in the future in one place without updating all project workflow references.