### PR TITLE
[No Ticket] - use remote types for interface testing

### DIFF
--- a/.github/workflows/standard_spa_pr_NPM.yml
+++ b/.github/workflows/standard_spa_pr_NPM.yml
@@ -182,7 +182,7 @@ jobs:
       # Validate runtime types (if applicable)
       - name: Validate Runtime Modules Types
         run: |
-          npx -p @jupiterone/web-runtime-modules testInterfaceRuntimeModules;
+          npx -p @jupiterone/web-tools-remote-types@latest remote-types test --skip-validation
           echo "No breaking changes found";
         if: ${{ !env.HAS_SKIP }}
 


### PR DESCRIPTION
The old tool we used for testing no longer supports interface testing per this release https://github.com/JupiterOne/web-runtime-modules/blob/main/CHANGELOG.md#v300-thu-apr-13-2023. This was released before it was fully thought through and now test will fail in CI/CD

Its replacement is ready but was not going to be formally released yet. In order to fix builds I have added `@jupiterone/web-tools-remote-types@latest` with the ` --skip-validation` flag which is functionally the same as the old interface test. 