### PR TITLE
Remove optional validation

### DIFF
--- a/.github/workflows/standard_spa_pr_NPM.yml
+++ b/.github/workflows/standard_spa_pr_NPM.yml
@@ -182,7 +182,7 @@ jobs:
       # Validate runtime types (if applicable)
       - name: Validate Runtime Modules Types
         run: |
-          npx -p @jupiterone/web-tools-remote-types@latest remote-types test --skip-validation
+          npx -p @jupiterone/web-tools-remote-types@latest remote-types test
           echo "No breaking changes found";
         if: ${{ !env.HAS_SKIP }}
 


### PR DESCRIPTION
Teams have been given a full sprint to respond to tighter PR validation preemptively. We are now enforcing that the package.json of all frontend repos includes:
* license
* name
* main
* config [optional unless they are using remote types]
  * bundle_name
  * dist
  * importedRuntimeModules (used by Jetpack)
  * exportedRuntimeModules (used by Jetpack)
 
This change will allow Titan to start work on Platform Compliance and improve app stability.