### PR TITLE
APP-11797

### DIFF
--- a/.github/workflows/standard_spa_pr_NPM.yml
+++ b/.github/workflows/standard_spa_pr_NPM.yml
@@ -353,7 +353,7 @@ jobs:
     container:
       image: cypress/browsers:node18.12.0-chrome106-ff106
       options: --platform linux/amd64 --privileged
-    timeout-minutes: 15
+    timeout-minutes: 25
     if: |
       always()
       && !cancelled()
@@ -372,7 +372,9 @@ jobs:
         node: [18]
     concurrency:
       group: run-e2e-tests-${{ needs.create-shared-vars.outputs.groupId }}-${{ matrix.containers }}
-      cancel-in-progress: true
+      # To avoid the following error, we leave this disabled: Canceling since a higher priority waiting request for 'run-e2e-tests-PR-web-settings-91-1' exists
+      # This still serves a purpose as any previously pending job in the concurrency group will be canceled, just not those already in progress
+      # cancel-in-progress: true
     steps:
       - name: Log E2E Info
         run: echo "Running E2E test for PR with title of ${{ inputs.external_pr_title || github.event.pull_request.title }} and number being ${{ inputs.external_pr_number || github.event.pull_request.number }}. The following account will be used ${{ needs.prepare_for_e2e_test.outputs.artemisAccountName }} (${{ needs.prepare_for_e2e_test.outputs.artemisAccountId }}). The following matrix container is being used ${{ matrix.containers }}"


### PR DESCRIPTION
As shown here, at times our E2E tests report timeouts to Slack. This can cause confusion among engineers who use these channels when monitoring failures in their E2E test suites.

<img width="613" alt="Screen Shot 2023-04-26 at 10 40 41 AM" src="https://user-images.githubusercontent.com/1964654/234611502-a51f658f-447a-4d79-8423-82cbd25288f4.png">

While we can't prevent timeouts from being reported to Slack from Cypress, we can try to cut down on the number of timeouts that occur. This PR addresses two of the primary reasons a timeout currently occurs:
- `The job running on runner jupiterone-dev-runner-amd64-spms6-0 has exceeded the maximum execution time of 15 minutes.` - [Example here](https://github.com/JupiterOne/web-settings/actions/runs/4749529854)
- `Canceling since a higher priority waiting request for 'run-e2e-tests-PR-web-... exists` - [Example here](https://github.com/JupiterOne/web-settings/actions/runs/4766793795)
