### PR TITLE
SRE should own workflow templates

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,4 @@
 * @jupiterone/security
+/.github/workflows/ @jupiterone/sre
+/workflow-templates/ @jupiterone/sre
 CODEOWNERS @jupiterone/security


### PR DESCRIPTION
@JupiterOne/sre and @JupiterOne/titan This will make SRE own the workflow templates instead of the security team, which is something Titan and I discussed as a way to help make sure both our teams are running the same direction with regards to CI/CD.