### PR TITLE
[No Ticket] - add npm token to build

### DIFF
--- a/.github/workflows/npm_package_pr_npm.yaml
+++ b/.github/workflows/npm_package_pr_npm.yaml
@@ -55,6 +55,8 @@ jobs:
       - run: npm rebuild esbuild
         if: ${{ inputs.use_esbuild }}
       - run: npm run build
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   chromatic-deployment:
     runs-on: ${{ inputs.runs_on }}

--- a/.github/workflows/npm_package_release_npm.yaml
+++ b/.github/workflows/npm_package_release_npm.yaml
@@ -76,6 +76,8 @@ jobs:
 
       - name: Run build
         run: npm run build
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # TODO: This is where security should add a security code scan
       # This is only what will be shipped to production and not any


### PR DESCRIPTION
## Context
We are starting to leverage `npx` to consolidate various configs. A new, still experimental, tool is web-tools-npm-deploy which will build npm packages with very little local config. This is called with 
```bash
npx --yes -p @jupiterone/web-tools-npm-deploy npm-deploy build
```

Projects that want to opt into this tool will add that to their build script in their package.json

## Issue

GH actions use least privilege by default when it comes to env variables. This means for `npm run build` to call a J1 npm package with npx it needs to have the `NODE_AUTH_TOKEN`
