### PR TITLE
add-cortex-flow

### DIFF
--- a/.github/workflows/cortex_frontend.yml
+++ b/.github/workflows/cortex_frontend.yml
@@ -1,0 +1,50 @@
+name: Runs Cortex related jobs for Frontend Projects
+
+on:
+  workflow_call:
+    inputs:
+      default_runner:
+        default: "['jupiterone-dev', 'arm64']"
+        type: string
+      github_runner:
+        default: "ubuntu-latest"
+        type: string
+      use_github_runner:
+        description: "If true will leverage ubuntu-latest, otherwise will fall back to the J1 in-house runner"
+        default: false
+        type: boolean
+    secrets:
+      NPM_TOKEN:
+        description: "A J1 npm.com Publish token"
+        required: true
+      CORTEX_API_KEY:
+        description: "An key that allows us to push data to Cortex"
+        required: true
+
+env:
+  CORTEX_API_KEY: ${{ secrets.CORTEX_API_KEY }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+  
+jobs:
+  cortex:
+    runs-on: ${{ inputs.use_github_runner && inputs.github_runner || fromJson(inputs.default_runner) }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.15.0
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - name: Create or update entity in Cortex
+        run: npx --yes -p @jupiterone/web-tools-platform-analytics@latest platform-analytics createService
+      - name: Collect Lint Metrics
+        run: npx --yes -p @jupiterone/web-tools-platform-analytics@latest platform-analytics lint
+      - name: Collect Unit Test Metrics
+        run: npx --yes -p @jupiterone/web-tools-platform-analytics@latest platform-analytics test
+      - name: Collect Build Metrics
+        run: npx --yes -p @jupiterone/web-tools-platform-analytics@latest platform-analytics build


### PR DESCRIPTION
Adds a new github flow to be leveraged by frontend projects that will allow us to dynamically push frontend related data into Cortex.