### PR TITLE
APP-13138 - allow project peer installs

### DIFF
--- a/.github/workflows/npm_package_pr_npm.yaml
+++ b/.github/workflows/npm_package_pr_npm.yaml
@@ -51,7 +51,7 @@ jobs:
       - run: npm run validate:ci
 
       # Sanity check so we don't end up with bad builds in main
-      - run: npm ci --ignore-scripts --omit=dev --omit=peer
+      - run: npm ci --ignore-scripts --omit=dev
       - run: npm rebuild esbuild
         if: ${{ inputs.use_esbuild }}
       - run: npm run build

--- a/.github/workflows/npm_package_release_npm.yaml
+++ b/.github/workflows/npm_package_release_npm.yaml
@@ -67,7 +67,7 @@ jobs:
           cache: "npm"
           registry-url: "https://registry.npmjs.org"
       # Only allow production deps be installed in the final build!
-      - run: npm ci --ignore-scripts --omit=dev --omit=peer
+      - run: npm ci --ignore-scripts --omit=dev
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       # run the esbuild build scrips


### PR DESCRIPTION
While standardizing our DTS rollup (ts type files) for our NPM package, we encountered an issue with peer deps. After investigating, we found our new tooling will install peers for bundling types. This is ideal for avoiding bundling types as `any` when a package is not found, as we had before.

We originally omitted peer when we had an excessive bundling issue, where the production code would reference packages that were not installed as deps. This was a stability and security concern. We now use depcheck to scan for cases like this and fail builds at the PR stage. Omitting peers is no longer required or a risk. 