### PR TITLE
APP-13243 - Adds a slack webhook notification action

### DIFF
--- a/.github/workflows/slack_webhook_notification.yml
+++ b/.github/workflows/slack_webhook_notification.yml
@@ -1,0 +1,36 @@
+name: Slack Webhook Notification
+
+on:
+  workflow_call:
+    inputs:
+      payload:
+        description: "A JSON payload to send to Slack"
+        type: string
+        required: true
+    secrets:
+      SLACK_WEBHOOK_URL:
+        description: "A Slack webhook URL to send a message to"
+        required: true
+
+jobs:
+  Slack_Notification:
+    runs-on: jupiterone-dev
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - run: echo "j1_email=$(git --no-pager show -s --format=\'%ae\')" >> $GITHUB_ENV
+      - id: find-slack-user
+        uses: scribd/find-slack-user-action@v1
+        with:
+          slack-token: ${{ secrets.SLACK_API_TOKEN }}
+          email: ${{ env.j1_email }}
+      - run: echo ${{ steps.find-slack-user.outputs.member-id }}
+      - run: |
+          appended_json=$(echo '${{ inputs.payload }}' | jq '.userId = "${{ steps.find-slack-user.outputs.member-id }}"')
+          echo "json=$(echo $appended_json)" >> $GITHUB_ENV
+      - uses: slackapi/slack-github-action@v1.24.0
+        with:
+          payload: ${{ env.json }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/slack_webhook_notification.yml
+++ b/.github/workflows/slack_webhook_notification.yml
@@ -29,7 +29,6 @@ jobs:
         with:
           slack-token: ${{ secrets.SLACK_API_TOKEN }}
           email: ${{ env.gh_email }}
-          include-at-symbol: true
       - name: "Append Slack User ID and Email to JSON"
         continue-on-error: true
         run: |

--- a/.github/workflows/slack_webhook_notification.yml
+++ b/.github/workflows/slack_webhook_notification.yml
@@ -11,6 +11,9 @@ on:
       SLACK_WEBHOOK_URL:
         description: "A Slack webhook URL to send a message to"
         required: true
+      FALLBACK_SLACK_WEBHOOK_URL:
+        description: "A Slack webhook URL to send a message to if thre is no Slack user found"
+        required: false
 
 jobs:
   Slack_Notification:
@@ -19,18 +22,29 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
-      - run: echo "j1_email=$(git --no-pager show -s --format=\'%ae\')" >> $GITHUB_ENV
+      - run: echo "gh_email=$(git --no-pager show -s --format=\'%ae\')" >> $GITHUB_ENV
       - id: find-slack-user
         uses: scribd/find-slack-user-action@v1
+        continue-on-error: true
         with:
           slack-token: ${{ secrets.SLACK_API_TOKEN }}
-          email: ${{ env.j1_email }}
-      - run: echo ${{ steps.find-slack-user.outputs.member-id }}
-      - run: |
-          appended_json=$(echo '${{ inputs.payload }}' | jq '.userId = "${{ steps.find-slack-user.outputs.member-id }}"')
+          email: ${{ env.gh_email }}
+          include-at-symbol: true
+      - name: "Append Slack User ID and Email to JSON"
+        continue-on-error: true
+        run: |
+          appended_json=$(echo '${{ inputs.payload }}' | jq '.userId = "${{ steps.find-slack-user.outputs.member-id || 'unknown' }}" | .email = "${{ env.gh_email }}"')
           echo "json=$(echo $appended_json)" >> $GITHUB_ENV
       - uses: slackapi/slack-github-action@v1.24.0
+        if: steps.find-slack-user.outputs.member-id
         with:
           payload: ${{ env.json }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      # Useful if a user is not found in Slack
+      - uses: slackapi/slack-github-action@v1.24.0
+        if: ${{ !steps.find-slack-user.outputs.member-id }}
+        with:
+          payload: ${{ env.json }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.FALLBACK_SLACK_WEBHOOK_URL || secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/slack_webhook_notification.yml
+++ b/.github/workflows/slack_webhook_notification.yml
@@ -1,5 +1,24 @@
 name: Slack Webhook Notification
 
+# Usage Example:
+# Assuming we want to send an alert to a Slack channel when the `pr` job fails
+# and we want to tag the GH user in the channel.
+#
+# report_failure:
+#   needs: pr
+#   if: failure()
+#   uses: jupiterone/.github/.github/workflows/slack_webhook_notification.yml
+#   with:
+#     payload: |
+#       {
+#         "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+#         "repo": "${{ github.repository }}"
+#       }
+#   secrets:
+#     # Tag user in the channel
+#     SLACK_WEBHOOK_URL: ${{ secrets.TEMP_SLACK_WEBHOOK_FAILURE }}
+#     # Tag all users in the channel with @here so we are sure this issue is seen
+#     FALLBACK_SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_FAILURE_FALLBACK }}
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/slack_webhook_notification.yml
+++ b/.github/workflows/slack_webhook_notification.yml
@@ -32,7 +32,7 @@ jobs:
       - name: "Append Slack User ID and Email to JSON"
         continue-on-error: true
         run: |
-          appended_json=$(echo '${{ inputs.payload }}' | jq '.userId = "${{ steps.find-slack-user.outputs.member-id || 'unknown' }}" | .email = "${{ env.gh_email }}"')
+          appended_json=$(echo '${{ inputs.payload }}' | jq '.userId = "${{ steps.find-slack-user.outputs.member-id }}" | .email = "${{ env.gh_email }}"')
           echo "json=$(echo $appended_json)" >> $GITHUB_ENV
       - uses: slackapi/slack-github-action@v1.24.0
         if: steps.find-slack-user.outputs.member-id


### PR DESCRIPTION
Creates a reusable action that calls a Slack webhook with an attached planeload. It also appends the current user ID based on the git email. This accepts two webhook URLs, one for if there is a userId and one for if the userId can't be found. Sadly the webhook will fail if it is expecting a userId, and than it's not valid. 

We would need to add two webhooks globally per messaging type to use this in mass. So this will end up with more GH secrets than I expected. I still feel the flexibility of calling Slack workflows has value.

Note SLACK_API_TOKEN is missing, I will need SRE and Security to both agree that we should add this globally. The fallback URL does work, however: https://jptrone.slack.com/archives/C01HDR0BPV1/p1689691570782199

