### PR TITLE
[No Ticket] - support edge case build before validate

### DIFF
--- a/.github/workflows/npm_package_pr_npm.yaml
+++ b/.github/workflows/npm_package_pr_npm.yaml
@@ -49,6 +49,8 @@ jobs:
         if: ${{ inputs.use_esbuild }}
 
       - run: npm run validate:ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # Sanity check so we don't end up with bad builds in main
       - run: npm ci --ignore-scripts --omit=dev

--- a/.github/workflows/npm_package_release_npm.yaml
+++ b/.github/workflows/npm_package_release_npm.yaml
@@ -50,6 +50,8 @@ jobs:
         if: ${{ inputs.use_esbuild }}
       - name: Validate
         run: npm run validate:ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   release:
     needs: validate


### PR DESCRIPTION
In some edge cases, `validate` may include running the project's build command first. Those cases will require the validate command have access to the read npm token.