### PR TITLE
[No Ticket] - Lock down runner to use arm64

### DIFF
--- a/.github/workflows/npm_package_pr_npm.yaml
+++ b/.github/workflows/npm_package_pr_npm.yaml
@@ -6,9 +6,11 @@ on:
   workflow_call:
     inputs:
       runs_on:
-        description: "What github runner should be used (e.g. jupiterone-dev)"
-        required: true
+        description: "Depricated"
         type: string
+      fallback_runner:
+        description: "Use a github runner instead of a JupiterOne runner"
+        type: boolean
       use_chromatic:
         description: "Does this release include chromatic"
         required: true
@@ -33,7 +35,7 @@ concurrency:
 jobs:
   validate:
     name: Validate
-    runs-on: ${{ inputs.runs_on }}
+    runs-on: ${{ (inputs.fallback_runner && 'ubuntu-latest') || fromJson('["jupiterone-dev", "arm64"]') }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
@@ -63,7 +65,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   chromatic-deployment:
-    runs-on: ${{ inputs.runs_on }}
+    runs-on: ${{ (inputs.fallback_runner && 'ubuntu-latest') || fromJson('["jupiterone-dev", "arm64"]') }}
     if: ${{ inputs.use_chromatic }}
     timeout-minutes: 15
     steps:

--- a/.github/workflows/npm_package_pr_npm.yaml
+++ b/.github/workflows/npm_package_pr_npm.yaml
@@ -6,7 +6,7 @@ on:
   workflow_call:
     inputs:
       runs_on:
-        description: "Depricated"
+        description: "Deprecated"
         type: string
       fallback_runner:
         description: "Use a github runner instead of a JupiterOne runner"

--- a/.github/workflows/npm_package_release_npm.yaml
+++ b/.github/workflows/npm_package_release_npm.yaml
@@ -5,7 +5,7 @@ on:
   workflow_call:
     inputs:
       runs_on:
-        description: "Depricated"
+        description: "Deprecated"
         type: string
       fallback_runner:
         description: "Use a github runner instead of a JupiterOne runner"

--- a/.github/workflows/npm_package_release_npm.yaml
+++ b/.github/workflows/npm_package_release_npm.yaml
@@ -5,9 +5,11 @@ on:
   workflow_call:
     inputs:
       runs_on:
-        description: "What github runner should be used (e.g. jupiterone-dev)"
-        required: true
+        description: "Depricated"
         type: string
+      fallback_runner:
+        description: "Use a github runner instead of a JupiterOne runner"
+        type: boolean
       use_chromatic:
         description: "Run VRT Storybook tests with chromatic"
         required: true
@@ -30,7 +32,7 @@ on:
 jobs:
   validate:
     name: Validate
-    runs-on: ${{ inputs.runs_on }}
+    runs-on: ${{ (inputs.fallback_runner && 'ubuntu-latest') || fromJson('["jupiterone-dev", "arm64"]') }}
     timeout-minutes: 15
     if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
     steps:
@@ -55,7 +57,7 @@ jobs:
 
   release:
     needs: validate
-    runs-on: ${{ inputs.runs_on }}
+    runs-on: ${{ (inputs.fallback_runner && 'ubuntu-latest') || fromJson('["jupiterone-dev", "arm64"]') }}
     timeout-minutes: 15
     name: Deploy to NPM
     steps:
@@ -97,7 +99,7 @@ jobs:
         run: npx auto shipit
 
   chromatic-deployment:
-    runs-on: ${{ inputs.runs_on }}
+    runs-on: ${{ (inputs.fallback_runner && 'ubuntu-latest') || fromJson('["jupiterone-dev", "arm64"]') }}
     timeout-minutes: 15
     if: ${{ inputs.use_chromatic }}
     steps:


### PR DESCRIPTION
We finally discovered why our NPM projects would randomly fail in production builds when using esbuild. We cache our npm installs, including esbuild, which installs os binaries. Under the hood, the OS kept switching on us and breaking the build because it was pulling from the cache. 