### PR TITLE
[No Ticket] - Add cortex to all FE NPM projects

### DIFF
--- a/.github/workflows/cortex_frontend.yml
+++ b/.github/workflows/cortex_frontend.yml
@@ -25,7 +25,7 @@ env:
   CORTEX_API_KEY: ${{ secrets.CORTEX_API_KEY }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-  
+
 jobs:
   cortex:
     runs-on: ${{ inputs.use_github_runner && inputs.github_runner || fromJson(inputs.default_runner) }}
@@ -37,14 +37,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.15.0
-          cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
+          cache: "npm"
+          registry-url: "https://registry.npmjs.org"
       - run: npm ci
       - name: Create or update entity in Cortex
-        run: npx --yes -p @jupiterone/web-tools-platform-analytics@latest platform-analytics createService
-      - name: Collect Lint Metrics
-        run: npx --yes -p @jupiterone/web-tools-platform-analytics@latest platform-analytics lint
-      - name: Collect Unit Test Metrics
-        run: npx --yes -p @jupiterone/web-tools-platform-analytics@latest platform-analytics test
-      - name: Collect Build Metrics
-        run: npx --yes -p @jupiterone/web-tools-platform-analytics@latest platform-analytics build
+        run: npx --yes -p @jupiterone/web-tools-platform-analytics@latest platform-analytics all

--- a/.github/workflows/npm_package_pr_npm.yaml
+++ b/.github/workflows/npm_package_pr_npm.yaml
@@ -26,6 +26,10 @@ on:
       CHROMATIC_PROJECT_TOKEN:
         description: "The Chromatic API token"
         required: false
+      CORTEX_API_KEY:
+        description: "An key that allows us to push data to Cortex"
+        # We eventually want to make this required but we need to make sure we don't break the pipeline
+        # required: true
 
 # Save Money :money_with_wings:
 concurrency:
@@ -91,3 +95,24 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           onlyChanged: true
           exitOnceUploaded: true
+  # This job will fail without CORTEX_API_KEY but it will not fall its parellel peer jobs
+  cortex:
+    runs-on: ${{ (inputs.fallback_runner && 'ubuntu-latest') || fromJson('["jupiterone-dev", "arm64"]') }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.15.0
+          cache: "npm"
+          registry-url: "https://registry.npmjs.org"
+      - run: npm ci --ignore-scripts
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Create or update entity in Cortex
+        run: npx --yes -p @jupiterone/web-tools-platform-analytics@latest platform-analytics all
+        env:
+          CORTEX_API_KEY: ${{ secrets.CORTEX_API_KEY }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The cortex project now uses an `all` command. So if we add new data points, we don't have to update CI/CD to start uploading that data to Cortex.

This also adds the Cortex uploaded to all frontend NPM projects. With this, everything frontend should be reporting in.