### PR TITLE
[No Ticket] - Target the Artemis package directly

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,8 +2,10 @@
 
 ## Publish Integration Image to Docker Hub and GHCR
 
-[This workflow](https://github.com/JupiterOne/.github/blob/main/.github/workflows/publish_docker_ghcr.yaml) builds and publishes your project to both Docker and GHCR.
-It is recommended that you only run this workflows on commits to your main branch, and on pushed tags following semver syntax. It does not need to run on PRs.
+[This workflow](https://github.com/JupiterOne/.github/blob/main/.github/workflows/publish_docker_ghcr.yaml)
+builds and publishes your project to both Docker and GHCR. It is recommended
+that you only run this workflows on commits to your main branch, and on pushed
+tags following semver syntax. It does not need to run on PRs.
 
 ### Inputs
 
@@ -21,10 +23,12 @@ This action requires uses the following inputs:
 
 ### Secrets
 
-These secrets are required to push to different image repositories. It is highly recommended to use `secrets: inherit` instead of supplying them directly.
+These secrets are required to push to different image repositories. It is highly
+recommended to use `secrets: inherit` instead of supplying them directly.
 
-> **Note**
-> Due to a limitation with how secrets are input, you must provide all four secrets even if you do not want to publish to both DockerHub and GHCR. You can use blank variables for these secrets if needed.
+> **Note** Due to a limitation with how secrets are input, you must provide all
+> four secrets even if you do not want to publish to both DockerHub and GHCR.
+> You can use blank variables for these secrets if needed.
 
 | Name              | Description                               |
 | ----------------- | ----------------------------------------- |
@@ -42,7 +46,7 @@ publish-image:
   if: ${{github.event_name != 'pull_request'}}
   uses: jupiterone/.github/.github/workflows/publish_docker_ghcr.yaml@v1.0.1
   with:
-    package-name: "jupiterone/error-reporting-service"
+    package-name: 'jupiterone/error-reporting-service'
   secrets: inherit
 ```
 
@@ -53,11 +57,11 @@ publish-image:
   if: ${{github.event_name != 'pull_request'}}
   uses: jupiterone/.github/.github/workflows/publish_docker_ghcr.yaml@v1.0.1
   with:
-    runs_on: "my-special-runner"
-    package-name: "jupiterone/error-reporting-service"
+    runs_on: 'my-special-runner'
+    package-name: 'jupiterone/error-reporting-service'
     push-to-registry: ${{github.event_name == 'merge'}}
-    build-platforms: "linux/amd64"
-    docker-context: "docker/"
+    build-platforms: 'linux/amd64'
+    docker-context: 'docker/'
   secrets:
     DOCKER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
     DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -67,8 +71,10 @@ publish-image:
 
 ## Publish Integration Image to Docker Hub
 
-[This workflow](https://github.com/JupiterOne/.github/blob/main/.github/workflows/publish_integration_docker_image.yaml) builds and publishes graph integration project to Docker Hub.
-It is recommended that you only run this workflows on commits to your main branch, and on pushed tags following semver syntax. It need not run on PRs.
+[This workflow](https://github.com/JupiterOne/.github/blob/main/.github/workflows/publish_integration_docker_image.yaml)
+builds and publishes graph integration project to Docker Hub. It is recommended
+that you only run this workflows on commits to your main branch, and on pushed
+tags following semver syntax. It need not run on PRs.
 
 ### Inputs
 
@@ -82,7 +88,8 @@ This action requires uses the following inputs:
 
 ### Secrets
 
-We HIGHLY recommend that these values are derived using your repos' action secrets
+We HIGHLY recommend that these values are derived using your repos' action
+secrets
 
 | Name           | Description                                                   |
 | -------------- | ------------------------------------------------------------- |
@@ -98,7 +105,7 @@ publish-image:
   if: ${{github.event_name != 'pull_request'}}
   uses: jupiterone/.github/.github/workflows/publish_integration_docker_image.yaml@v1.0.0
   with:
-    package-name: "jupiterone/graph-kubernetes"
+    package-name: 'jupiterone/graph-kubernetes'
   secrets:
     DOCKER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
     DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -111,8 +118,8 @@ publish-image:
   if: ${{github.event_name != 'pull_request'}}
   uses: jupiterone/.github/.github/workflows/publish_integration_docker_image.yaml@v1.0.0
   with:
-    runs_on: "my-special-runner"
-    package-name: "jupiterone/graph-kubernetes"
+    runs_on: 'my-special-runner'
+    package-name: 'jupiterone/graph-kubernetes'
     push-to-registry: ${{github.event_name == 'merge'}}
   secrets:
     DOCKER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/cortex_frontend.yml
+++ b/.github/workflows/cortex_frontend.yml
@@ -7,18 +7,20 @@ on:
         default: "['jupiterone-dev', 'arm64']"
         type: string
       github_runner:
-        default: "ubuntu-latest"
+        default: 'ubuntu-latest'
         type: string
       use_github_runner:
-        description: "If true will leverage ubuntu-latest, otherwise will fall back to the J1 in-house runner"
+        description:
+          'If true will leverage ubuntu-latest, otherwise will fall back to the
+          J1 in-house runner'
         default: false
         type: boolean
     secrets:
       NPM_TOKEN:
-        description: "A J1 npm.com Publish token"
+        description: 'A J1 npm.com Publish token'
         required: true
       CORTEX_API_KEY:
-        description: "An key that allows us to push data to Cortex"
+        description: 'An key that allows us to push data to Cortex'
         required: true
 
 env:
@@ -28,7 +30,9 @@ env:
 
 jobs:
   cortex:
-    runs-on: ${{ inputs.use_github_runner && inputs.github_runner || fromJson(inputs.default_runner) }}
+    runs-on:
+      ${{ inputs.use_github_runner && inputs.github_runner ||
+      fromJson(inputs.default_runner) }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
@@ -37,8 +41,10 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.15.0
-          cache: "npm"
-          registry-url: "https://registry.npmjs.org"
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - name: Create or update entity in Cortex
-        run: npx --yes -p @jupiterone/web-tools-platform-analytics@latest platform-analytics all
+        run:
+          npx --yes -p @jupiterone/web-tools-platform-analytics@latest
+          platform-analytics all

--- a/.github/workflows/e2e_trigger.yml
+++ b/.github/workflows/e2e_trigger.yml
@@ -13,27 +13,29 @@ on:
         default: "['jupiterone-dev', 'arm64']"
         type: string
       e2e_pass_on_error:
-        description: "Pass the workflow even if the E2E test fail"
+        description: 'Pass the workflow even if the E2E test fail'
         type: boolean
         default: true
       github_runner:
-        default: "ubuntu-latest"
+        default: 'ubuntu-latest'
         type: string
       repos_to_test:
-        description: "Kick off a n+ spec files within n+ repos"
+        description: 'Kick off a n+ spec files within n+ repos'
         type: string
       use_github_runner:
-        description: "If true will leverage ubuntu-latest, otherwise will fall back to the J1 in-house runner"
+        description:
+          'If true will leverage ubuntu-latest, otherwise will fall back to the
+          J1 in-house runner'
         default: false
         type: boolean
       use_e2e_trigger:
-        description: "Trigger E2E tests in other repos"
+        description: 'Trigger E2E tests in other repos'
         type: boolean
       group_id:
         type: string
     secrets:
       E2E_AUTO:
-        description: "A J1 token for kicking off cypress tests"
+        description: 'A J1 token for kicking off cypress tests'
         required: false
 
 jobs:
@@ -41,10 +43,14 @@ jobs:
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}
-    runs-on: ${{ inputs.use_github_runner && inputs.github_runner || fromJson(inputs.default_runner) }}
+    runs-on:
+      ${{ inputs.use_github_runner && inputs.github_runner ||
+      fromJson(inputs.default_runner) }}
     timeout-minutes: 60
     concurrency:
-      group: run-e2e-integration-tests-${{ inputs.group_id || github.head_ref || github.run_id }}
+      group:
+        run-e2e-integration-tests-${{ inputs.group_id || github.head_ref ||
+        github.run_id }}
       # To avoid the following error, we leave this disabled: Canceling since a higher priority waiting request for 'run-e2e-tests-PR-web-settings-91-1' exists
       # This still serves a purpose as any previously pending job in the concurrency group will be canceled, just not those already in progress
       # cancel-in-progress: true
@@ -56,9 +62,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Log E2E Info
-        run: echo "In the ${{ matrix.repos.repo.name }} repo, run the following test ${{ matrix.repos.repo.spec }}"
+        run:
+          echo "In the ${{ matrix.repos.repo.name }} repo, run the following
+          test ${{ matrix.repos.repo.spec }}"
       - name: Get author name
-        run: echo "COMMIT_INFO_AUTHOR=$(git show -s --pretty=%an)" >> $GITHUB_ENV
+        run:
+          echo "COMMIT_INFO_AUTHOR=$(git show -s --pretty=%an)" >> $GITHUB_ENV
       - name: Trigger Workflow and Wait
         id: trigger_run
         continue-on-error: ${{ inputs.e2e_pass_on_error }}
@@ -69,7 +78,14 @@ jobs:
           github_token: ${{ secrets.E2E_AUTO }}
           workflow_file_name: e2e_trigger.yml
           propagate_failure: ${{ !inputs.e2e_pass_on_error }}
-          client_payload: '{"spec_to_run":"${{ matrix.repos.repo.spec }}","external_pr_number":"${{ github.event.pull_request.number }}","external_pr_title":"${{ github.event.pull_request.title }}","external_pr_repo_name":"${{ github.event.repository.name }}","external_pr_branch":"${{ github.event.pull_request.head.ref }}","external_pr_author":"${{ env.COMMIT_INFO_AUTHOR }}","external_pr_sha":"${{ github.event.pull_request.base.sha }}"}'
+          client_payload:
+            '{"spec_to_run":"${{ matrix.repos.repo.spec
+            }}","external_pr_number":"${{ github.event.pull_request.number
+            }}","external_pr_title":"${{ github.event.pull_request.title
+            }}","external_pr_repo_name":"${{ github.event.repository.name
+            }}","external_pr_branch":"${{ github.event.pull_request.head.ref
+            }}","external_pr_author":"${{ env.COMMIT_INFO_AUTHOR
+            }}","external_pr_sha":"${{ github.event.pull_request.base.sha }}"}'
       # We have to manually output an exit code of 0 to ensure the action passes if e2e_pass_on_error is true
       - name: Pass with failures
         if: ${{ inputs.e2e_pass_on_error }}

--- a/.github/workflows/jetpack_frontend.yaml
+++ b/.github/workflows/jetpack_frontend.yaml
@@ -4,7 +4,9 @@ on:
   workflow_call:
     inputs:
       api_env:
-        description: 'The api environment for execution of this jetpack run. Should be dev or prod.'
+        description:
+          'The api environment for execution of this jetpack run. Should be dev
+          or prod.'
         required: true
         default: 'prod'
         type: string
@@ -18,7 +20,10 @@ on:
         type: string
         default: 'launch -v'
       jetpack_docker_image:
-        description: 'The jetpack docker image to run in this workflow. This is set by default, so unless overriding on purpose, please do not supply this value.'
+        description:
+          'The jetpack docker image to run in this workflow. This is set by
+          default, so unless overriding on purpose, please do not supply this
+          value.'
         type: string
         default: 'ghcr.io/jupiterone/jetpack-frontend-deploy:initial-2'
       repo_name:

--- a/.github/workflows/launchdarkly.yaml
+++ b/.github/workflows/launchdarkly.yaml
@@ -4,16 +4,21 @@ on:
   workflow_call:
     inputs:
       PROJECT_KEY:
-        description: LaunchDarkly project key, can be found at https://app.launchdarkly.com/settings/projects
+        description:
+          LaunchDarkly project key, can be found at
+          https://app.launchdarkly.com/settings/projects
         required: true
         type: string
     secrets:
       LD_ACCESS_TOKEN:
-        description: Access token for LaunchDarkly. Security can add this to your repository
+        description:
+          Access token for LaunchDarkly. Security can add this to your
+          repository
         required: true
 # cancel in-flight workflow run if another push was triggered
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group:
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 jobs:
   launchDarklyCodeReferences:

--- a/.github/workflows/npm_package_pr_npm.yaml
+++ b/.github/workflows/npm_package_pr_npm.yaml
@@ -6,44 +6,49 @@ on:
   workflow_call:
     inputs:
       runs_on:
-        description: "Deprecated"
+        description: 'Deprecated'
         type: string
       fallback_runner:
-        description: "Use a github runner instead of a JupiterOne runner"
+        description: 'Use a github runner instead of a JupiterOne runner'
         type: boolean
       use_chromatic:
-        description: "Does this release include chromatic"
+        description: 'Does this release include chromatic'
         required: true
         type: boolean
       use_esbuild:
-        description: "If using esbuild, insure its required build scripts are run"
+        description:
+          'If using esbuild, insure its required build scripts are run'
         required: false
         type: boolean
     secrets:
       NPM_TOKEN:
-        description: "A J1 npm.com Publish token"
+        description: 'A J1 npm.com Publish token'
         required: true
       CHROMATIC_PROJECT_TOKEN:
-        description: "The Chromatic API token"
+        description: 'The Chromatic API token'
         required: false
 
 # Save Money :money_with_wings:
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.repository.name }}-${{ github.event.pull_request.number || github.ref }}
+  group:
+    ${{ github.workflow }}-${{ github.event.repository.name }}-${{
+    github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   validate:
     name: Validate
-    runs-on: ${{ (inputs.fallback_runner && 'ubuntu-latest') || fromJson('["jupiterone-dev", "arm64"]') }}
+    runs-on:
+      ${{ (inputs.fallback_runner && 'ubuntu-latest') ||
+      fromJson('["jupiterone-dev", "arm64"]') }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-          cache: "npm"
-          registry-url: "https://registry.npmjs.org"
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
       - run: npm ci --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -65,7 +70,9 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   chromatic-deployment:
-    runs-on: ${{ (inputs.fallback_runner && 'ubuntu-latest') || fromJson('["jupiterone-dev", "arm64"]') }}
+    runs-on:
+      ${{ (inputs.fallback_runner && 'ubuntu-latest') ||
+      fromJson('["jupiterone-dev", "arm64"]') }}
     if: ${{ inputs.use_chromatic }}
     timeout-minutes: 15
     steps:
@@ -75,8 +82,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-          cache: "npm"
-          registry-url: "https://registry.npmjs.org"
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
       - run: npm ci --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm_package_release_npm.yaml
+++ b/.github/workflows/npm_package_release_npm.yaml
@@ -5,47 +5,54 @@ on:
   workflow_call:
     inputs:
       runs_on:
-        description: "Deprecated"
+        description: 'Deprecated'
         type: string
       fallback_runner:
-        description: "Use a github runner instead of a JupiterOne runner"
+        description: 'Use a github runner instead of a JupiterOne runner'
         type: boolean
       use_chromatic:
-        description: "Run VRT Storybook tests with chromatic"
+        description: 'Run VRT Storybook tests with chromatic'
         required: true
         type: boolean
       use_esbuild:
-        description: "If using esbuild, insure its required build scripts are run"
+        description:
+          'If using esbuild, insure its required build scripts are run'
         required: false
         type: boolean
     secrets:
       NPM_TOKEN:
-        description: "A J1 npm.com Publish token"
+        description: 'A J1 npm.com Publish token'
         required: true
       CHROMATIC_PROJECT_TOKEN:
-        description: "The Chromatic API token"
+        description: 'The Chromatic API token'
         required: false
       AUTO_GITHUB_PAT_TOKEN:
-        description: "This is a GitHuh PAT that let's auto write back to main after npm versioning"
+        description:
+          "This is a GitHuh PAT that let's auto write back to main after npm
+          versioning"
         required: true
       CORTEX_API_KEY:
-        description: "An key that allows us to push data to Cortex"
+        description: 'An key that allows us to push data to Cortex'
         # We eventually want to make this required but we need to make sure we don't break the pipeline
         # required: true
 
 jobs:
   validate:
     name: Validate
-    runs-on: ${{ (inputs.fallback_runner && 'ubuntu-latest') || fromJson('["jupiterone-dev", "arm64"]') }}
+    runs-on:
+      ${{ (inputs.fallback_runner && 'ubuntu-latest') ||
+      fromJson('["jupiterone-dev", "arm64"]') }}
     timeout-minutes: 15
-    if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
+    if:
+      "!contains(github.event.head_commit.message, 'ci skip') &&
+      !contains(github.event.head_commit.message, 'skip ci')"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-          cache: "npm"
-          registry-url: "https://registry.npmjs.org"
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
       # Never install npm packages with build scrips!
       # This is an easy way for attackers to get read out the process.env
       # or inject code into the bundle
@@ -61,7 +68,9 @@ jobs:
 
   release:
     needs: validate
-    runs-on: ${{ (inputs.fallback_runner && 'ubuntu-latest') || fromJson('["jupiterone-dev", "arm64"]') }}
+    runs-on:
+      ${{ (inputs.fallback_runner && 'ubuntu-latest') ||
+      fromJson('["jupiterone-dev", "arm64"]') }}
     timeout-minutes: 15
     name: Deploy to NPM
     steps:
@@ -72,8 +81,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-          cache: "npm"
-          registry-url: "https://registry.npmjs.org"
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
       # Only allow production deps be installed in the final build!
       - run: npm ci --ignore-scripts --omit=dev
         env:
@@ -103,7 +112,9 @@ jobs:
         run: npx auto shipit
 
   chromatic-deployment:
-    runs-on: ${{ (inputs.fallback_runner && 'ubuntu-latest') || fromJson('["jupiterone-dev", "arm64"]') }}
+    runs-on:
+      ${{ (inputs.fallback_runner && 'ubuntu-latest') ||
+      fromJson('["jupiterone-dev", "arm64"]') }}
     timeout-minutes: 15
     if: ${{ inputs.use_chromatic }}
     steps:
@@ -113,8 +124,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-          cache: "npm"
-          registry-url: "https://registry.npmjs.org"
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
       - run: npm ci --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -132,7 +143,9 @@ jobs:
 
   # This job will fail without CORTEX_API_KEY but it will not fall its parellel peer jobs
   cortex:
-    runs-on: ${{ (inputs.fallback_runner && 'ubuntu-latest') || fromJson('["jupiterone-dev", "arm64"]') }}
+    runs-on:
+      ${{ (inputs.fallback_runner && 'ubuntu-latest') ||
+      fromJson('["jupiterone-dev", "arm64"]') }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
@@ -141,13 +154,15 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.15.0
-          cache: "npm"
-          registry-url: "https://registry.npmjs.org"
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
       - run: npm ci --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Create or update entity in Cortex
-        run: npx --yes -p @jupiterone/web-tools-platform-analytics@latest platform-analytics all
+        run:
+          npx --yes -p @jupiterone/web-tools-platform-analytics@latest
+          platform-analytics all
         env:
           CORTEX_API_KEY: ${{ secrets.CORTEX_API_KEY }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish_docker_ghcr.yaml
+++ b/.github/workflows/publish_docker_ghcr.yaml
@@ -4,53 +4,54 @@ on:
   workflow_call:
     inputs:
       runs_on:
-        description: "What Github runner should be used (defaults to ubuntu-latest)"
+        description:
+          'What Github runner should be used (defaults to ubuntu-latest)'
         type: string
         required: false
-        default: "ubuntu-latest"
+        default: 'ubuntu-latest'
       package-name:
-        description: "Name of package to publish to Docker Hub"
+        description: 'Name of package to publish to Docker Hub'
         required: true
         type: string
       push-to-registry:
         description:
-          "Determines if the built image should be pushed to the registry (will
-          only push on a merge by default)"
+          'Determines if the built image should be pushed to the registry (will
+          only push on a merge by default)'
         required: false
         default: ${{github.event_name != 'pull_request'}}
         type: boolean
       docker-context:
-        description: "The Docker context to use when building the image"
+        description: 'The Docker context to use when building the image'
         required: false
         default: .
         type: string
       build-platforms:
-        description: "The platforms to build Docker images for"
+        description: 'The platforms to build Docker images for'
         required: false
-        default: "linux/amd64,linux/arm64"
+        default: 'linux/amd64,linux/arm64'
         type: string
       publish-to-docker:
-        description: "Should the image be published to DockerHub"
+        description: 'Should the image be published to DockerHub'
         required: false
         default: true
         type: boolean
       publish-to-ghcr:
-        description: "Should the image be published to GHCR"
+        description: 'Should the image be published to GHCR'
         required: false
         default: true
         type: boolean
     secrets:
       DOCKER_USERNAME:
-        description: "Docker username to authenticate and publish with"
+        description: 'Docker username to authenticate and publish with'
         required: true
       DOCKER_PASSWORD:
-        description: "Docker password to authenticate and publish with"
+        description: 'Docker password to authenticate and publish with'
         required: true
       GHCR_USERNAME:
-        description: "GHCR Username to authenticate and publish with"
+        description: 'GHCR Username to authenticate and publish with'
         required: true
       GHCR_PASSWORD:
-        description: "GHCR password to authenticate and publish with"
+        description: 'GHCR password to authenticate and publish with'
         required: true
 jobs:
   build-image:

--- a/.github/workflows/publish_integration_docker_image.yaml
+++ b/.github/workflows/publish_integration_docker_image.yaml
@@ -4,67 +4,64 @@ on:
   workflow_call:
     inputs:
       runs_on:
-        description: "What Github runner should be used (defaults to ubuntu-latest)"
+        description:
+          'What Github runner should be used (defaults to ubuntu-latest)'
         type: string
         required: false
-        default: "ubuntu-latest"
+        default: 'ubuntu-latest'
       package-name:
-        description: "Name of package to publish to Docker Hub"
+        description: 'Name of package to publish to Docker Hub'
         required: true
         type: string
       push-to-registry:
-        description: "Determines if the built image should be pushed to the registry (will only push on a merge by default)"
+        description:
+          'Determines if the built image should be pushed to the registry (will
+          only push on a merge by default)'
         required: false
         default: ${{github.event_name != 'pull_request'}}
         type: boolean
     secrets:
       DOCKER_USERNAME:
-        description: "Docker username to authenticate and publish with"
+        description: 'Docker username to authenticate and publish with'
         required: true
       DOCKER_PASSWORD:
-        description: "Docker password to authenticate and publish with"
+        description: 'Docker password to authenticate and publish with'
         required: true
 jobs:
   build_publish_docker_image:
     name: build and publish image
     runs-on: ${{ inputs.runs_on }}
     steps:
-    -
-      name: Checkout
-      uses: actions/checkout@v3
-    -
-      name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
-    -
-      name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
-    -
-      name: Docker meta
-      id: meta
-      uses: docker/metadata-action@v4
-      with:
-        images: ${{ inputs.package-name }}
-        # generate Docker tags based on the following events/attributes
-        tags: |
-           type=schedule
-           type=ref,event=branch
-           type=ref,event=pr
-           type=semver,pattern={{version}}
-           type=semver,pattern={{major}}.{{minor}}
-           type=semver,pattern={{major}}
-           type=sha
-    -
-      name: Login to DockerHub
-      uses: docker/login-action@v2
-      with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-    -
-      name: Build and push
-      uses: docker/build-push-action@v3
-      with:
-        context: .
-        platforms: linux/amd64,linux/arm64
-        push: ${{ inputs.push-to-registry == true }}
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ inputs.package-name }}
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ inputs.push-to-registry == true }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish_to_docker_registries.yaml
+++ b/.github/workflows/publish_to_docker_registries.yaml
@@ -4,53 +4,54 @@ on:
   workflow_call:
     inputs:
       runs_on:
-        description: "What Github runner should be used (defaults to ubuntu-latest)"
+        description:
+          'What Github runner should be used (defaults to ubuntu-latest)'
         type: string
         required: false
-        default: "ubuntu-latest"
+        default: 'ubuntu-latest'
       package-name:
-        description: "Name of package to publish to Docker Hub"
+        description: 'Name of package to publish to Docker Hub'
         required: true
         type: string
       push-to-registry:
         description:
-          "Determines if the built image should be pushed to the registry (will
-          only push on a merge by default)"
+          'Determines if the built image should be pushed to the registry (will
+          only push on a merge by default)'
         required: false
         default: ${{github.event_name != 'pull_request'}}
         type: boolean
       docker-context:
-        description: "The Docker context to use when building the image"
+        description: 'The Docker context to use when building the image'
         required: false
         default: .
         type: string
       build-platforms:
-        description: "The platforms to build Docker images for"
+        description: 'The platforms to build Docker images for'
         required: false
-        default: "linux/amd64,linux/arm64"
+        default: 'linux/amd64,linux/arm64'
         type: string
       publish-to-docker:
-        description: "Should the image be published to DockerHub"
+        description: 'Should the image be published to DockerHub'
         required: false
         default: true
         type: boolean
       publish-to-ghcr:
-        description: "Should the image be published to GHCR"
+        description: 'Should the image be published to GHCR'
         required: false
         default: true
         type: boolean
     secrets:
       DOCKER_USERNAME:
-        description: "Docker username to authenticate and publish with"
+        description: 'Docker username to authenticate and publish with'
         required: true
       DOCKER_PASSWORD:
-        description: "Docker password to authenticate and publish with"
+        description: 'Docker password to authenticate and publish with'
         required: true
       GHCR_USERNAME:
-        description: "GHCR Username to authenticate and publish with"
+        description: 'GHCR Username to authenticate and publish with'
         required: true
       GHCR_PASSWORD:
-        description: "GHCR password to authenticate and publish with"
+        description: 'GHCR password to authenticate and publish with'
         required: true
 jobs:
   build-image:

--- a/.github/workflows/standard_spa_pr.yml
+++ b/.github/workflows/standard_spa_pr.yml
@@ -4,11 +4,10 @@ on:
   workflow_call:
     inputs:
       working_directory:
-        description:
-          'The working directory from which to run the workflow commands'
+        description: "The working directory from which to run the workflow commands"
         required: false
         type: string
-        default: '.'
+        default: "."
       runs_on:
         description: "Deprecated noop - To be removed"
         type: string
@@ -58,39 +57,39 @@ on:
         type: boolean
         default: false
       e2e_artemis_config_path:
-        description: 'Used to determine the path to the artemis config file'
+        description: "Used to determine the path to the artemis config file"
         type: string
-        default: 'cypress/artemis-config.yaml'
+        default: "cypress/artemis-config.yaml"
       external_pr_number:
-        description: 'Used by the e2e_trigger to pass in the PR number associated with the PR that triggered the flow'
+        description: "Used by the e2e_trigger to pass in the PR number associated with the PR that triggered the flow"
         type: string
       external_pr_title:
-        description: 'Used by the e2e_trigger to give builds in Cypress the correct title associated with the PR that triggered the flow'
+        description: "Used by the e2e_trigger to give builds in Cypress the correct title associated with the PR that triggered the flow"
         type: string
       external_pr_branch:
-        description: 'Used by the e2e_trigger to give builds in Cypress the correct branch name'
+        description: "Used by the e2e_trigger to give builds in Cypress the correct branch name"
         type: string
       external_pr_author:
-        description: 'Used by the e2e_trigger to give builds in Cypress the correct author name associated with the owner of the PR'
+        description: "Used by the e2e_trigger to give builds in Cypress the correct author name associated with the owner of the PR"
         type: string
       external_pr_sha:
-        description: 'Used by the e2e_trigger to give builds in Cypress the correct SHA associated with the PR that triggered the flow'
+        description: "Used by the e2e_trigger to give builds in Cypress the correct SHA associated with the PR that triggered the flow"
         type: string
       external_pr_repo_name:
-        description: 'Used by the e2e_trigger to tag builds in Cypress with the appropriate repo name (used to associate a repo with a test run)'
+        description: "Used by the e2e_trigger to tag builds in Cypress with the appropriate repo name (used to associate a repo with a test run)"
         type: string
       externally_triggered:
-        description: 'True if E2E tests are triggered from another repo'
+        description: "True if E2E tests are triggered from another repo"
         default: false
         type: boolean
       spec_to_run:
-        description: 'Used to determine which test to run'
+        description: "Used to determine which test to run"
         type: string
-        default: 'cypress/e2e/**/*.feature'
-      magic_url_route: 
-        description: 'The relative route the magic url should go to'
+        default: "cypress/e2e/**/*.feature"
+      magic_url_route:
+        description: "The relative route the magic url should go to"
         type: string
-        default: '/'
+        default: "/"
     secrets:
       NPM_TOKEN:
         description: "A J1 npm.com Publish token"
@@ -165,8 +164,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.15.0
-          cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
+          cache: "npm"
+          registry-url: "https://registry.npmjs.org"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: npm ci
@@ -204,8 +203,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.15.0
-          cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
+          cache: "npm"
+          registry-url: "https://registry.npmjs.org"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: npm ci
@@ -236,8 +235,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.15.0
-          cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
+          cache: "npm"
+          registry-url: "https://registry.npmjs.org"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - id: packageJson
@@ -266,8 +265,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.15.0
-          cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
+          cache: "npm"
+          registry-url: "https://registry.npmjs.org"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: npm ci
@@ -277,8 +276,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE }}
-          role-session-name:
-            ${{ github.event.repository.name }}-magic-url-role-session
+          role-session-name: ${{ github.event.repository.name }}-magic-url-role-session
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Deploy
         # This bucket file location is static and editing it will break the Magic URL. This pushes the entire directory which includes the bundle and remote types if applicable
@@ -297,10 +295,10 @@ jobs:
     steps:
       - name: Return Magic URL
         uses: Sibz/github-status-action@v1
-        with: 
+        with:
           authToken: ${{ secrets.GITHUB_TOKEN }}
-          state: 'success'
-          context: 'Magic URL'
+          state: "success"
+          context: "Magic URL"
           description: "Use the 'Details' link to view this PR in dev"
           target_url: https://apps.dev.jupiterone.io${{ inputs.magic_url_route }}?magic2=%7B%22${{ github.event.repository.name }}%40${{ needs.migration_number.outputs.migration }}%22:%22PR-${{ github.event.pull_request.number }}%22%7D
           sha: ${{github.event.pull_request.head.sha || github.sha}}
@@ -333,8 +331,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.15.0
-          cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
+          cache: "npm"
+          registry-url: "https://registry.npmjs.org"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: npm ci
@@ -342,13 +340,12 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE }}
-          role-session-name:
-            ${{ github.event.repository.name }}-magic-url-role-session
+          role-session-name: ${{ github.event.repository.name }}-magic-url-role-session
           aws-region: us-east-1
       - name: update artemis config
-        run: npx update-artemis-config --pathToArtemisConfig=${{ inputs.e2e_artemis_config_path }} --usersCount=${{ needs.create-shared-vars.outputs.usersCount }}
+        run: npx --yes -p @jupiterone/artemis@latest update-artemis-config --pathToArtemisConfig=${{ inputs.e2e_artemis_config_path }} --usersCount=${{ needs.create-shared-vars.outputs.usersCount }}
       - name: launch artemis
-        run: npx artemis-launch -c tmp/artemis-config-updated.yaml --action=launch --outputFilename=artemis-run
+        run: npx --yes -p @jupiterone/artemis@latest artemis-launch -c tmp/artemis-config-updated.yaml --action=launch --outputFilename=artemis-run
       - id: accountInfo
         # Use jq to extract the accountId and user sessions from the json file in a raw form
         run: |
@@ -374,13 +371,14 @@ jobs:
       always()
       && !cancelled()
       && inputs.use_e2e
-    needs: [create-shared-vars, magic_url, migration_number, prepare_for_e2e_test]
+    needs:
+      [create-shared-vars, magic_url, migration_number, prepare_for_e2e_test]
     continue-on-error: ${{ inputs.e2e_pass_on_error && !inputs.externally_triggered }}
     strategy:
       # when one test fails, DO NOT cancel the other
       # containers, because this will kill Cypress processes
       # leaving Cypress Cloud hanging ...
-      # https://github.com/cypress-io/github-action/issues/48 
+      # https://github.com/cypress-io/github-action/issues/48
       fail-fast: false
       matrix:
         # run copies of the current job in parallel
@@ -406,8 +404,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.15.0
-          cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
+          cache: "npm"
+          registry-url: "https://registry.npmjs.org"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Cypress run
@@ -424,7 +422,7 @@ jobs:
           tag: ${{ inputs.external_pr_repo_name || github.event.repository.name }},${{ github.event_name }}
         env:
           # https://github.com/cypress-io/cypress/issues/25357#issuecomment-1426992422
-          ELECTRON_EXTRA_LAUNCH_ARGS: '--disable-gpu'
+          ELECTRON_EXTRA_LAUNCH_ARGS: "--disable-gpu"
           CYPRESS_BROWSER: chrome
           COMMIT_INFO_MESSAGE: ${{ inputs.external_pr_title || github.event.pull_request.title }}
           COMMIT_INFO_BRANCH: ${{ inputs.external_pr_branch }}
@@ -469,7 +467,7 @@ jobs:
         continue-on-error: ${{ inputs.e2e_pass_on_error }}
         with:
           authToken: ${{secrets.GITHUB_TOKEN}}
-          context: 'E2E Test Status'
+          context: "E2E Test Status"
           description: ${{ env.TEST_STATUS_DESCRIPTION }}
           state: ${{ env.TEST_STATUS_STATE }}
           sha: ${{github.event.pull_request.head.sha || github.sha}}

--- a/.github/workflows/standard_spa_pr.yml
+++ b/.github/workflows/standard_spa_pr.yml
@@ -4,12 +4,13 @@ on:
   workflow_call:
     inputs:
       working_directory:
-        description: "The working directory from which to run the workflow commands"
+        description:
+          'The working directory from which to run the workflow commands'
         required: false
         type: string
-        default: "."
+        default: '.'
       runs_on:
-        description: "Deprecated noop - To be removed"
+        description: 'Deprecated noop - To be removed'
         type: string
       default_runner:
         default: "['jupiterone-dev', 'arm64']"
@@ -18,105 +19,121 @@ on:
         default: "['jupiterone-dev', 'amd64']"
         type: string
       github_runner:
-        default: "ubuntu-latest"
+        default: 'ubuntu-latest'
         type: string
       use_github_runner:
-        description: "If true will levarege ubuntu-latest, otherwise will fall back to the J1 in-house runner"
+        description:
+          'If true will levarege ubuntu-latest, otherwise will fall back to the
+          J1 in-house runner'
         default: false
         type: boolean
       use_validate:
-        description: "Run test, in most case we want this"
+        description: 'Run test, in most case we want this'
         required: true
         type: boolean
       use_chromatic:
-        description: "Run VRT Storybook tests with chromatic"
+        description: 'Run VRT Storybook tests with chromatic'
         required: true
         type: boolean
       use_magic_url:
-        description: "Deploy to dev via a query param, required for normal SPAs"
+        description: 'Deploy to dev via a query param, required for normal SPAs'
         required: true
         type: boolean
       use_e2e:
-        description: "Run E2E test, in most case we want this"
+        description: 'Run E2E test, in most case we want this'
         type: boolean
       use_e2e_trigger:
-        description: "Trigger E2E tests in other repos"
+        description: 'Trigger E2E tests in other repos'
         type: boolean
       e2e_filter_tags:
-        description: "Tests will be filtered based on the tags defined here"
+        description: 'Tests will be filtered based on the tags defined here'
         type: string
       repos_to_test:
-        description: "Kick off a n+ spec files within n+ repos"
+        description: 'Kick off a n+ spec files within n+ repos'
         type: string
       e2e_containers:
-        description: "The number of tests that you want Cypress to run in parallel (ex. 1, 2, 3, ...)"
+        description:
+          'The number of tests that you want Cypress to run in parallel (ex. 1,
+          2, 3, ...)'
         type: string
         default: '["1"]'
       e2e_pass_on_error:
-        description: "Pass the workflow even if the E2E test fail"
+        description: 'Pass the workflow even if the E2E test fail'
         type: boolean
         default: false
       e2e_artemis_config_path:
-        description: "Used to determine the path to the artemis config file"
+        description: 'Used to determine the path to the artemis config file'
         type: string
-        default: "cypress/artemis-config.yaml"
+        default: 'cypress/artemis-config.yaml'
       external_pr_number:
-        description: "Used by the e2e_trigger to pass in the PR number associated with the PR that triggered the flow"
+        description:
+          'Used by the e2e_trigger to pass in the PR number associated with the
+          PR that triggered the flow'
         type: string
       external_pr_title:
-        description: "Used by the e2e_trigger to give builds in Cypress the correct title associated with the PR that triggered the flow"
+        description:
+          'Used by the e2e_trigger to give builds in Cypress the correct title
+          associated with the PR that triggered the flow'
         type: string
       external_pr_branch:
-        description: "Used by the e2e_trigger to give builds in Cypress the correct branch name"
+        description:
+          'Used by the e2e_trigger to give builds in Cypress the correct branch
+          name'
         type: string
       external_pr_author:
-        description: "Used by the e2e_trigger to give builds in Cypress the correct author name associated with the owner of the PR"
+        description:
+          'Used by the e2e_trigger to give builds in Cypress the correct author
+          name associated with the owner of the PR'
         type: string
       external_pr_sha:
-        description: "Used by the e2e_trigger to give builds in Cypress the correct SHA associated with the PR that triggered the flow"
+        description:
+          'Used by the e2e_trigger to give builds in Cypress the correct SHA
+          associated with the PR that triggered the flow'
         type: string
       external_pr_repo_name:
-        description: "Used by the e2e_trigger to tag builds in Cypress with the appropriate repo name (used to associate a repo with a test run)"
+        description:
+          'Used by the e2e_trigger to tag builds in Cypress with the appropriate
+          repo name (used to associate a repo with a test run)'
         type: string
       externally_triggered:
-        description: "True if E2E tests are triggered from another repo"
+        description: 'True if E2E tests are triggered from another repo'
         default: false
         type: boolean
       spec_to_run:
-        description: "Used to determine which test to run"
+        description: 'Used to determine which test to run'
         type: string
-        default: "cypress/e2e/**/*.feature"
+        default: 'cypress/e2e/**/*.feature'
       magic_url_route:
-        description: "The relative route the magic url should go to"
+        description: 'The relative route the magic url should go to'
         type: string
-        default: "/"
+        default: '/'
     secrets:
       NPM_TOKEN:
-        description: "A J1 npm.com Publish token"
+        description: 'A J1 npm.com Publish token'
         required: true
       CHROMATIC_PROJECT_TOKEN:
-        description: "The Chromatic API token"
+        description: 'The Chromatic API token'
         required: false
       AWS_ROLE:
-        description: "J1 AWS role with deploy permissions to dev"
+        description: 'J1 AWS role with deploy permissions to dev'
         required: false
       AWS_REGION:
-        description: "The current region of the dev env"
+        description: 'The current region of the dev env'
         required: false
       AWS_APPS_BUCKET:
-        description: "What bucket to deploy the magic url"
+        description: 'What bucket to deploy the magic url'
         required: false
       CYPRESS_RECORD_KEY:
-        description: "The record key associated with the project in Cypress"
+        description: 'The record key associated with the project in Cypress'
         required: false
       CYPRESS_PROJECT_ID:
-        description: "The project ID associated with the project in Cypress"
+        description: 'The project ID associated with the project in Cypress'
         required: false
       CYPRESS_PASSWORD:
-        description: "The password of the E2E username"
+        description: 'The password of the E2E username'
         required: false
       E2E_AUTO:
-        description: "A J1 token for kicking off cypress tests"
+        description: 'A J1 token for kicking off cypress tests'
         required: false
 
 jobs:
@@ -124,8 +141,12 @@ jobs:
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}
-    name: Creates shared variables used by the the jobs below based on whether the jobs were triggered by another repo or internally
-    runs-on: ${{ inputs.use_github_runner && inputs.github_runner || fromJson(inputs.default_runner) }}
+    name:
+      Creates shared variables used by the the jobs below based on whether the
+      jobs were triggered by another repo or internally
+    runs-on:
+      ${{ inputs.use_github_runner && inputs.github_runner ||
+      fromJson(inputs.default_runner) }}
     timeout-minutes: 15
     outputs:
       groupId: ${{ steps.externalTrigger.outputs.groupId }}
@@ -150,7 +171,9 @@ jobs:
       run:
         working-directory: ${{ inputs.working_directory }}
     name: Validate
-    runs-on: ${{ inputs.use_github_runner && inputs.github_runner || fromJson(inputs.default_runner) }}
+    runs-on:
+      ${{ inputs.use_github_runner && inputs.github_runner ||
+      fromJson(inputs.default_runner) }}
     timeout-minutes: 15
     concurrency:
       group: validate-${{ needs.create-shared-vars.outputs.groupId }}
@@ -164,8 +187,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.15.0
-          cache: "npm"
-          registry-url: "https://registry.npmjs.org"
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: npm ci
@@ -189,10 +212,13 @@ jobs:
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}
-    runs-on: ${{ inputs.use_github_runner && inputs.github_runner || fromJson(inputs.default_runner) }}
+    runs-on:
+      ${{ inputs.use_github_runner && inputs.github_runner ||
+      fromJson(inputs.default_runner) }}
     timeout-minutes: 15
     concurrency:
-      group: chromatic-deployment-${{ needs.create-shared-vars.outputs.groupId }}
+      group:
+        chromatic-deployment-${{ needs.create-shared-vars.outputs.groupId }}
       cancel-in-progress: true
     needs: [create-shared-vars]
     if: ${{ inputs.use_chromatic }}
@@ -203,8 +229,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.15.0
-          cache: "npm"
-          registry-url: "https://registry.npmjs.org"
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: npm ci
@@ -222,7 +248,9 @@ jobs:
       run:
         working-directory: ${{ inputs.working_directory }}
     name: Deploy To Dev
-    runs-on: ${{ inputs.use_github_runner && inputs.github_runner || fromJson(inputs.default_runner) }}
+    runs-on:
+      ${{ inputs.use_github_runner && inputs.github_runner ||
+      fromJson(inputs.default_runner) }}
     timeout-minutes: 15
     concurrency:
       group: migration_number-${{ needs.create-shared-vars.outputs.groupId }}
@@ -235,8 +263,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.15.0
-          cache: "npm"
-          registry-url: "https://registry.npmjs.org"
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - id: packageJson
@@ -249,7 +277,9 @@ jobs:
       run:
         working-directory: ${{ inputs.working_directory }}
     name: Deploy To Dev
-    runs-on: ${{ inputs.use_github_runner && inputs.github_runner || fromJson(inputs.default_runner) }}
+    runs-on:
+      ${{ inputs.use_github_runner && inputs.github_runner ||
+      fromJson(inputs.default_runner) }}
     timeout-minutes: 15
     concurrency:
       group: deploy-magic-url-${{ needs.create-shared-vars.outputs.groupId }}
@@ -265,8 +295,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.15.0
-          cache: "npm"
-          registry-url: "https://registry.npmjs.org"
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: npm ci
@@ -276,7 +306,8 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE }}
-          role-session-name: ${{ github.event.repository.name }}-magic-url-role-session
+          role-session-name:
+            ${{ github.event.repository.name }}-magic-url-role-session
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Deploy
         # This bucket file location is static and editing it will break the Magic URL. This pushes the entire directory which includes the bundle and remote types if applicable
@@ -285,7 +316,9 @@ jobs:
 
   magic_url:
     name: Post Magic URL
-    runs-on: ${{ inputs.use_github_runner && inputs.github_runner || fromJson(inputs.default_runner) }}
+    runs-on:
+      ${{ inputs.use_github_runner && inputs.github_runner ||
+      fromJson(inputs.default_runner) }}
     timeout-minutes: 1
     concurrency:
       group: magic-url-${{ needs.create-shared-vars.outputs.groupId }}
@@ -297,10 +330,14 @@ jobs:
         uses: Sibz/github-status-action@v1
         with:
           authToken: ${{ secrets.GITHUB_TOKEN }}
-          state: "success"
-          context: "Magic URL"
+          state: 'success'
+          context: 'Magic URL'
           description: "Use the 'Details' link to view this PR in dev"
-          target_url: https://apps.dev.jupiterone.io${{ inputs.magic_url_route }}?magic2=%7B%22${{ github.event.repository.name }}%40${{ needs.migration_number.outputs.migration }}%22:%22PR-${{ github.event.pull_request.number }}%22%7D
+          target_url:
+            https://apps.dev.jupiterone.io${{ inputs.magic_url_route
+            }}?magic2=%7B%22${{ github.event.repository.name }}%40${{
+            needs.migration_number.outputs.migration }}%22:%22PR-${{
+            github.event.pull_request.number }}%22%7D
           sha: ${{github.event.pull_request.head.sha || github.sha}}
 
   prepare_for_e2e_test:
@@ -308,10 +345,13 @@ jobs:
       run:
         working-directory: ${{ inputs.working_directory }}
     name: Prepare Artemis
-    runs-on: ${{ inputs.use_github_runner && inputs.github_runner || fromJson(inputs.default_runner) }}
+    runs-on:
+      ${{ inputs.use_github_runner && inputs.github_runner ||
+      fromJson(inputs.default_runner) }}
     timeout-minutes: 15
     concurrency:
-      group: prepare-for-e2e-test-${{ needs.create-shared-vars.outputs.groupId }}
+      group:
+        prepare-for-e2e-test-${{ needs.create-shared-vars.outputs.groupId }}
       cancel-in-progress: true
     needs: [create-shared-vars]
     # We need this job to run even if the magic url is skipped which occurs via the e2e_trigger.yml
@@ -323,7 +363,8 @@ jobs:
     outputs:
       artemisAccountName: ${{ steps.accountInfo.outputs.artemisAccountName }}
       artemisAccountId: ${{ steps.accountInfo.outputs.artemisAccountId }}
-      artemisAccountSubdomain: ${{ steps.accountInfo.outputs.artemisAccountSubdomain }}
+      artemisAccountSubdomain:
+        ${{ steps.accountInfo.outputs.artemisAccountSubdomain }}
       # compact JSON of [{csrf:string,secret:string,subject:string},...]
       artemisUsers: ${{ steps.userInfo.outputs.artemisUsers }}
     steps:
@@ -331,8 +372,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.15.0
-          cache: "npm"
-          registry-url: "https://registry.npmjs.org"
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: npm ci
@@ -340,12 +381,19 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE }}
-          role-session-name: ${{ github.event.repository.name }}-magic-url-role-session
+          role-session-name:
+            ${{ github.event.repository.name }}-magic-url-role-session
           aws-region: us-east-1
       - name: update artemis config
-        run: npx --yes -p @jupiterone/artemis@latest update-artemis-config --pathToArtemisConfig=${{ inputs.e2e_artemis_config_path }} --usersCount=${{ needs.create-shared-vars.outputs.usersCount }}
+        run:
+          npx --yes -p @jupiterone/artemis@latest update-artemis-config
+          --pathToArtemisConfig=${{ inputs.e2e_artemis_config_path }}
+          --usersCount=${{ needs.create-shared-vars.outputs.usersCount }}
       - name: launch artemis
-        run: npx --yes -p @jupiterone/artemis@latest artemis-launch -c tmp/artemis-config-updated.yaml --action=launch --outputFilename=artemis-run
+        run:
+          npx --yes -p @jupiterone/artemis@latest artemis-launch -c
+          tmp/artemis-config-updated.yaml --action=launch
+          --outputFilename=artemis-run
       - id: accountInfo
         # Use jq to extract the accountId and user sessions from the json file in a raw form
         run: |
@@ -361,8 +409,12 @@ jobs:
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}
-    name: Run E2E Tests for ${{ needs.create-shared-vars.outputs.e2eJobDescription }}
-    runs-on: ${{ inputs.use_github_runner && inputs.github_runner || fromJson(inputs.e2e_runner) }}
+    name:
+      Run E2E Tests for ${{ needs.create-shared-vars.outputs.e2eJobDescription
+      }}
+    runs-on:
+      ${{ inputs.use_github_runner && inputs.github_runner ||
+      fromJson(inputs.e2e_runner) }}
     container:
       image: cypress/browsers:node18.12.0-chrome106-ff106
       options: --platform linux/amd64 --privileged
@@ -373,7 +425,8 @@ jobs:
       && inputs.use_e2e
     needs:
       [create-shared-vars, magic_url, migration_number, prepare_for_e2e_test]
-    continue-on-error: ${{ inputs.e2e_pass_on_error && !inputs.externally_triggered }}
+    continue-on-error:
+      ${{ inputs.e2e_pass_on_error && !inputs.externally_triggered }}
     strategy:
       # when one test fails, DO NOT cancel the other
       # containers, because this will kill Cypress processes
@@ -385,13 +438,22 @@ jobs:
         containers: ${{ fromJson(inputs.e2e_containers) }}
         node: [18]
     concurrency:
-      group: run-e2e-tests-${{ needs.create-shared-vars.outputs.groupId }}-${{ matrix.containers }}
+      group:
+        run-e2e-tests-${{ needs.create-shared-vars.outputs.groupId }}-${{
+        matrix.containers }}
       # To avoid the following error, we leave this disabled: Canceling since a higher priority waiting request for 'run-e2e-tests-PR-web-settings-91-1' exists
       # This still serves a purpose as any previously pending job in the concurrency group will be canceled, just not those already in progress
       # cancel-in-progress: true
     steps:
       - name: Log E2E Info
-        run: echo "Running E2E test for PR with title of ${{ inputs.external_pr_title || github.event.pull_request.title }} and number being ${{ inputs.external_pr_number || github.event.pull_request.number }}. The following account will be used ${{ needs.prepare_for_e2e_test.outputs.artemisAccountName }} (${{ needs.prepare_for_e2e_test.outputs.artemisAccountId }}). The following matrix container is being used ${{ matrix.containers }}"
+        run:
+          echo "Running E2E test for PR with title of ${{
+          inputs.external_pr_title || github.event.pull_request.title }} and
+          number being ${{ inputs.external_pr_number ||
+          github.event.pull_request.number }}. The following account will be
+          used ${{ needs.prepare_for_e2e_test.outputs.artemisAccountName }} (${{
+          needs.prepare_for_e2e_test.outputs.artemisAccountId }}). The following
+          matrix container is being used ${{ matrix.containers }}"
       - name: Log groupId
         run: echo "groupId - ${{ needs.create-shared-vars.outputs.groupId }}"
       - name: Log status of prepare_for_e2e_test job
@@ -404,27 +466,34 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.15.0
-          cache: "npm"
-          registry-url: "https://registry.npmjs.org"
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Cypress run
         id: cypress_run
-        continue-on-error: ${{ inputs.e2e_pass_on_error && !inputs.externally_triggered }}
+        continue-on-error:
+          ${{ inputs.e2e_pass_on_error && !inputs.externally_triggered }}
         uses: cypress-io/github-action@v5
         timeout-minutes: 60
         with:
           record: true
           parallel: true
           group: PR
-          ci-build-id: "${{ inputs.external_pr_sha || github.sha }}-${{ github.workflow }}-${{ github.event_name }}-${{ inputs.external_pr_number || github.event.pull_request.number }}"
+          ci-build-id:
+            '${{ inputs.external_pr_sha || github.sha }}-${{ github.workflow
+            }}-${{ github.event_name }}-${{ inputs.external_pr_number ||
+            github.event.pull_request.number }}'
           browser: chrome
-          tag: ${{ inputs.external_pr_repo_name || github.event.repository.name }},${{ github.event_name }}
+          tag:
+            ${{ inputs.external_pr_repo_name || github.event.repository.name
+            }},${{ github.event_name }}
         env:
           # https://github.com/cypress-io/cypress/issues/25357#issuecomment-1426992422
-          ELECTRON_EXTRA_LAUNCH_ARGS: "--disable-gpu"
+          ELECTRON_EXTRA_LAUNCH_ARGS: '--disable-gpu'
           CYPRESS_BROWSER: chrome
-          COMMIT_INFO_MESSAGE: ${{ inputs.external_pr_title || github.event.pull_request.title }}
+          COMMIT_INFO_MESSAGE:
+            ${{ inputs.external_pr_title || github.event.pull_request.title }}
           COMMIT_INFO_BRANCH: ${{ inputs.external_pr_branch }}
           COMMIT_INFO_AUTHOR: ${{ inputs.external_pr_author }}
           COMMIT_INFO_SHA: ${{ inputs.external_pr_sha }}
@@ -437,11 +506,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           MIGRATION_NUMBER: ${{ needs.migration_number.outputs.migration }}
-          PR_NUMBER: ${{ inputs.external_pr_number || github.event.pull_request.number }}
-          REPO_NAME: ${{ inputs.external_pr_repo_name || github.event.repository.name }}
+          PR_NUMBER:
+            ${{ inputs.external_pr_number || github.event.pull_request.number }}
+          REPO_NAME:
+            ${{ inputs.external_pr_repo_name || github.event.repository.name }}
           SPEC: ${{ inputs.spec_to_run }}
           ACCOUNT: ${{ needs.prepare_for_e2e_test.outputs.artemisAccountName }}
-          ACCOUNT_SUBDOMAIN: ${{ needs.prepare_for_e2e_test.outputs.artemisAccountSubdomain }}
+          ACCOUNT_SUBDOMAIN:
+            ${{ needs.prepare_for_e2e_test.outputs.artemisAccountSubdomain }}
           ACCOUNT_ID: ${{ needs.prepare_for_e2e_test.outputs.artemisAccountId }}
           USERS: ${{ needs.prepare_for_e2e_test.outputs.artemisUsers }}
           TAGS: ${{ inputs.e2e_filter_tags }}
@@ -452,12 +524,16 @@ jobs:
       - name: Set success vars
         # Need to check previous TEST_STATUS_STATE to ensure it hasn't already failed
         # important if multiple containers are in use to ensure the correct status is reported
-        if: ${{ inputs.e2e_pass_on_error && contains(steps.cypress_run.outcome, 'success') && !contains(env.TEST_STATUS_STATE, 'failure') }}
+        if:
+          ${{ inputs.e2e_pass_on_error && contains(steps.cypress_run.outcome,
+          'success') && !contains(env.TEST_STATUS_STATE, 'failure') }}
         run: |
           echo "TEST_STATUS_STATE=success" >> $GITHUB_ENV
           echo "TEST_STATUS_DESCRIPTION='E2E test passed'" >> $GITHUB_ENV
       - name: Set failure vars
-        if: ${{ inputs.e2e_pass_on_error && !contains(steps.cypress_run.outcome, 'success') }}
+        if:
+          ${{ inputs.e2e_pass_on_error && !contains(steps.cypress_run.outcome,
+          'success') }}
         run: |
           echo "TEST_STATUS_STATE=failure" >> $GITHUB_ENV
           echo "TEST_STATUS_DESCRIPTION='E2E test failed'" >> $GITHUB_ENV
@@ -467,7 +543,7 @@ jobs:
         continue-on-error: ${{ inputs.e2e_pass_on_error }}
         with:
           authToken: ${{secrets.GITHUB_TOKEN}}
-          context: "E2E Test Status"
+          context: 'E2E Test Status'
           description: ${{ env.TEST_STATUS_DESCRIPTION }}
           state: ${{ env.TEST_STATUS_STATE }}
           sha: ${{github.event.pull_request.head.sha || github.sha}}

--- a/.github/workflows/standard_spa_pr_NPM.yml
+++ b/.github/workflows/standard_spa_pr_NPM.yml
@@ -4,12 +4,13 @@ on:
   workflow_call:
     inputs:
       working_directory:
-        description: "The working directory from which to run the workflow commands"
+        description:
+          'The working directory from which to run the workflow commands'
         required: false
         type: string
-        default: "."
+        default: '.'
       runs_on:
-        description: "Deprecated noop - To be removed"
+        description: 'Deprecated noop - To be removed'
         type: string
       default_runner:
         default: "['jupiterone-dev', 'arm64']"
@@ -18,105 +19,121 @@ on:
         default: "['jupiterone-dev', 'amd64']"
         type: string
       github_runner:
-        default: "ubuntu-latest"
+        default: 'ubuntu-latest'
         type: string
       use_github_runner:
-        description: "If true will levarege ubuntu-latest, otherwise will fall back to the J1 in-house runner"
+        description:
+          'If true will levarege ubuntu-latest, otherwise will fall back to the
+          J1 in-house runner'
         default: false
         type: boolean
       use_validate:
-        description: "Run test, in most case we want this"
+        description: 'Run test, in most case we want this'
         required: true
         type: boolean
       use_chromatic:
-        description: "Run VRT Storybook tests with chromatic"
+        description: 'Run VRT Storybook tests with chromatic'
         required: true
         type: boolean
       use_magic_url:
-        description: "Deploy to dev via a query param, required for normal SPAs"
+        description: 'Deploy to dev via a query param, required for normal SPAs'
         required: true
         type: boolean
       use_e2e:
-        description: "Run E2E test, in most case we want this"
+        description: 'Run E2E test, in most case we want this'
         type: boolean
       use_e2e_trigger:
-        description: "Trigger E2E tests in other repos"
+        description: 'Trigger E2E tests in other repos'
         type: boolean
       e2e_filter_tags:
-        description: "Tests will be filtered based on the tags defined here"
+        description: 'Tests will be filtered based on the tags defined here'
         type: string
       repos_to_test:
-        description: "Kick off a n+ spec files within n+ repos"
+        description: 'Kick off a n+ spec files within n+ repos'
         type: string
       e2e_containers:
-        description: "The number of tests that you want Cypress to run in parallel (ex. 1, 2, 3, ...)"
+        description:
+          'The number of tests that you want Cypress to run in parallel (ex. 1,
+          2, 3, ...)'
         type: string
         default: '["1"]'
       e2e_pass_on_error:
-        description: "Pass the workflow even if the E2E test fail"
+        description: 'Pass the workflow even if the E2E test fail'
         type: boolean
         default: true
       e2e_artemis_config_path:
-        description: "Used to determine the path to the artemis config file"
+        description: 'Used to determine the path to the artemis config file'
         type: string
-        default: "cypress/artemis-config.yaml"
+        default: 'cypress/artemis-config.yaml'
       external_pr_number:
-        description: "Used by the e2e_trigger to pass in the PR number associated with the PR that triggered the flow"
+        description:
+          'Used by the e2e_trigger to pass in the PR number associated with the
+          PR that triggered the flow'
         type: string
       external_pr_title:
-        description: "Used by the e2e_trigger to give builds in Cypress the correct title associated with the PR that triggered the flow"
+        description:
+          'Used by the e2e_trigger to give builds in Cypress the correct title
+          associated with the PR that triggered the flow'
         type: string
       external_pr_branch:
-        description: "Used by the e2e_trigger to give builds in Cypress the correct branch name"
+        description:
+          'Used by the e2e_trigger to give builds in Cypress the correct branch
+          name'
         type: string
       external_pr_author:
-        description: "Used by the e2e_trigger to give builds in Cypress the correct author name associated with the owner of the PR"
+        description:
+          'Used by the e2e_trigger to give builds in Cypress the correct author
+          name associated with the owner of the PR'
         type: string
       external_pr_sha:
-        description: "Used by the e2e_trigger to give builds in Cypress the correct SHA associated with the PR that triggered the flow"
+        description:
+          'Used by the e2e_trigger to give builds in Cypress the correct SHA
+          associated with the PR that triggered the flow'
         type: string
       external_pr_repo_name:
-        description: "Used by the e2e_trigger to tag builds in Cypress with the appropriate repo name (used to associate a repo with a test run)"
+        description:
+          'Used by the e2e_trigger to tag builds in Cypress with the appropriate
+          repo name (used to associate a repo with a test run)'
         type: string
       externally_triggered:
-        description: "True if E2E tests are triggered from another repo"
+        description: 'True if E2E tests are triggered from another repo'
         default: false
         type: boolean
       spec_to_run:
-        description: "Used to determine which test to run"
+        description: 'Used to determine which test to run'
         type: string
-        default: "cypress/e2e/**/*.feature"
+        default: 'cypress/e2e/**/*.feature'
       magic_url_route:
-        description: "The relative route the magic url should go to"
+        description: 'The relative route the magic url should go to'
         type: string
-        default: "/"
+        default: '/'
     secrets:
       NPM_TOKEN:
-        description: "A J1 npm.com Publish token"
+        description: 'A J1 npm.com Publish token'
         required: true
       CHROMATIC_PROJECT_TOKEN:
-        description: "The Chromatic API token"
+        description: 'The Chromatic API token'
         required: false
       AWS_ROLE:
-        description: "J1 AWS role with deploy permissions to dev"
+        description: 'J1 AWS role with deploy permissions to dev'
         required: false
       AWS_REGION:
-        description: "The current region of the dev env"
+        description: 'The current region of the dev env'
         required: false
       AWS_APPS_BUCKET:
-        description: "What bucket to deploy the magic url"
+        description: 'What bucket to deploy the magic url'
         required: false
       CYPRESS_RECORD_KEY:
-        description: "The record key associated with the project in Cypress"
+        description: 'The record key associated with the project in Cypress'
         required: false
       CYPRESS_PROJECT_ID:
-        description: "The project ID associated with the project in Cypress"
+        description: 'The project ID associated with the project in Cypress'
         required: false
       CYPRESS_PASSWORD:
-        description: "The password of the E2E username"
+        description: 'The password of the E2E username'
         required: false
       E2E_AUTO:
-        description: "A J1 token for kicking off cypress tests"
+        description: 'A J1 token for kicking off cypress tests'
         required: false
 
 jobs:
@@ -124,8 +141,12 @@ jobs:
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}
-    name: Creates shared variables used by the the jobs below based on whether the jobs were triggered by another repo or internally
-    runs-on: ${{ inputs.use_github_runner && inputs.github_runner || fromJson(inputs.default_runner) }}
+    name:
+      Creates shared variables used by the the jobs below based on whether the
+      jobs were triggered by another repo or internally
+    runs-on:
+      ${{ inputs.use_github_runner && inputs.github_runner ||
+      fromJson(inputs.default_runner) }}
     timeout-minutes: 15
     outputs:
       groupId: ${{ steps.externalTrigger.outputs.groupId }}
@@ -150,7 +171,9 @@ jobs:
       run:
         working-directory: ${{ inputs.working_directory }}
     name: Validate
-    runs-on: ${{ inputs.use_github_runner && inputs.github_runner || fromJson(inputs.default_runner) }}
+    runs-on:
+      ${{ inputs.use_github_runner && inputs.github_runner ||
+      fromJson(inputs.default_runner) }}
     timeout-minutes: 15
     concurrency:
       group: validate-${{ needs.create-shared-vars.outputs.groupId }}
@@ -164,8 +187,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.15.0
-          cache: "npm"
-          registry-url: "https://registry.npmjs.org"
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: npm ci
@@ -189,10 +212,13 @@ jobs:
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}
-    runs-on: ${{ inputs.use_github_runner && inputs.github_runner || fromJson(inputs.default_runner) }}
+    runs-on:
+      ${{ inputs.use_github_runner && inputs.github_runner ||
+      fromJson(inputs.default_runner) }}
     timeout-minutes: 15
     concurrency:
-      group: chromatic-deployment-${{ needs.create-shared-vars.outputs.groupId }}
+      group:
+        chromatic-deployment-${{ needs.create-shared-vars.outputs.groupId }}
       cancel-in-progress: true
     needs: [create-shared-vars]
     if: ${{ inputs.use_chromatic }}
@@ -203,8 +229,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.15.0
-          cache: "npm"
-          registry-url: "https://registry.npmjs.org"
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: npm ci
@@ -222,7 +248,9 @@ jobs:
       run:
         working-directory: ${{ inputs.working_directory }}
     name: Deploy To Dev
-    runs-on: ${{ inputs.use_github_runner && inputs.github_runner || fromJson(inputs.default_runner) }}
+    runs-on:
+      ${{ inputs.use_github_runner && inputs.github_runner ||
+      fromJson(inputs.default_runner) }}
     timeout-minutes: 15
     concurrency:
       group: deploy-magic-url-${{ needs.create-shared-vars.outputs.groupId }}
@@ -238,8 +266,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.15.0
-          cache: "npm"
-          registry-url: "https://registry.npmjs.org"
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: npm ci
@@ -250,7 +278,8 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE }}
-          role-session-name: ${{ github.event.repository.name }}-magic-url-role-session
+          role-session-name:
+            ${{ github.event.repository.name }}-magic-url-role-session
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Deploy
         # This bucket file location is static and editing it will break the Magic URL
@@ -260,7 +289,9 @@ jobs:
 
   magic_url:
     name: Post Magic URL
-    runs-on: ${{ inputs.use_github_runner && inputs.github_runner || fromJson(inputs.default_runner) }}
+    runs-on:
+      ${{ inputs.use_github_runner && inputs.github_runner ||
+      fromJson(inputs.default_runner) }}
     timeout-minutes: 1
     concurrency:
       group: magic-url-${{ needs.create-shared-vars.outputs.groupId }}
@@ -272,10 +303,13 @@ jobs:
         uses: Sibz/github-status-action@v1
         with:
           authToken: ${{ secrets.GITHUB_TOKEN }}
-          state: "success"
-          context: "Magic URL"
+          state: 'success'
+          context: 'Magic URL'
           description: "Use the 'Details' link to view this PR in dev"
-          target_url: https://apps.dev.jupiterone.io${{ inputs.magic_url_route }}?magic=%7B%22${{ github.event.repository.name }}%22:%22PR-${{ github.event.pull_request.number }}%22%7D
+          target_url:
+            https://apps.dev.jupiterone.io${{ inputs.magic_url_route
+            }}?magic=%7B%22${{ github.event.repository.name }}%22:%22PR-${{
+            github.event.pull_request.number }}%22%7D
           sha: ${{github.event.pull_request.head.sha || github.sha}}
 
   prepare_for_e2e_test:
@@ -283,10 +317,13 @@ jobs:
       run:
         working-directory: ${{ inputs.working_directory }}
     name: Prepare Artemis
-    runs-on: ${{ inputs.use_github_runner && inputs.github_runner || fromJson(inputs.default_runner) }}
+    runs-on:
+      ${{ inputs.use_github_runner && inputs.github_runner ||
+      fromJson(inputs.default_runner) }}
     timeout-minutes: 15
     concurrency:
-      group: prepare-for-e2e-test-${{ needs.create-shared-vars.outputs.groupId }}
+      group:
+        prepare-for-e2e-test-${{ needs.create-shared-vars.outputs.groupId }}
       cancel-in-progress: true
     needs: [create-shared-vars]
     # We need this job to run even if the magic url is skipped which occurs via the e2e_trigger.yml
@@ -298,7 +335,8 @@ jobs:
     outputs:
       artemisAccountName: ${{ steps.accountInfo.outputs.artemisAccountName }}
       artemisAccountId: ${{ steps.accountInfo.outputs.artemisAccountId }}
-      artemisAccountSubdomain: ${{ steps.accountInfo.outputs.artemisAccountSubdomain }}
+      artemisAccountSubdomain:
+        ${{ steps.accountInfo.outputs.artemisAccountSubdomain }}
       # compact JSON of [{csrf:string,secret:string,subject:string},...]
       artemisUsers: ${{ steps.userInfo.outputs.artemisUsers }}
     steps:
@@ -306,8 +344,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.15.0
-          cache: "npm"
-          registry-url: "https://registry.npmjs.org"
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: npm ci
@@ -315,12 +353,18 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE }}
-          role-session-name: ${{ github.event.repository.name }}-magic-url-role-session
+          role-session-name:
+            ${{ github.event.repository.name }}-magic-url-role-session
           aws-region: us-east-1
       - name: update artemis config
-        run: npx update-artemis-config --pathToArtemisConfig=${{ inputs.e2e_artemis_config_path }} --usersCount=${{ needs.create-shared-vars.outputs.usersCount }}
+        run:
+          npx update-artemis-config --pathToArtemisConfig=${{
+          inputs.e2e_artemis_config_path }} --usersCount=${{
+          needs.create-shared-vars.outputs.usersCount }}
       - name: launch artemis
-        run: npx artemis-launch -c tmp/artemis-config-updated.yaml --action=launch --outputFilename=artemis-run
+        run:
+          npx artemis-launch -c tmp/artemis-config-updated.yaml --action=launch
+          --outputFilename=artemis-run
       - id: accountInfo
         # Use jq to extract the accountId and user sessions from the json file in a raw form
         run: |
@@ -336,8 +380,12 @@ jobs:
     defaults:
       run:
         working-directory: ${{ inputs.working_directory }}
-    name: Run E2E Tests for ${{ needs.create-shared-vars.outputs.e2eJobDescription }}
-    runs-on: ${{ inputs.use_github_runner && inputs.github_runner || fromJson(inputs.e2e_runner) }}
+    name:
+      Run E2E Tests for ${{ needs.create-shared-vars.outputs.e2eJobDescription
+      }}
+    runs-on:
+      ${{ inputs.use_github_runner && inputs.github_runner ||
+      fromJson(inputs.e2e_runner) }}
     container:
       image: cypress/browsers:node18.12.0-chrome106-ff106
       options: --platform linux/amd64 --privileged
@@ -359,13 +407,22 @@ jobs:
         containers: ${{ fromJson(inputs.e2e_containers) }}
         node: [18]
     concurrency:
-      group: run-e2e-tests-${{ needs.create-shared-vars.outputs.groupId }}-${{ matrix.containers }}
+      group:
+        run-e2e-tests-${{ needs.create-shared-vars.outputs.groupId }}-${{
+        matrix.containers }}
       # To avoid the following error, we leave this disabled: Canceling since a higher priority waiting request for 'run-e2e-tests-PR-web-settings-91-1' exists
       # This still serves a purpose as any previously pending job in the concurrency group will be canceled, just not those already in progress
       # cancel-in-progress: true
     steps:
       - name: Log E2E Info
-        run: echo "Running E2E test for PR with title of ${{ inputs.external_pr_title || github.event.pull_request.title }} and number being ${{ inputs.external_pr_number || github.event.pull_request.number }}. The following account will be used ${{ needs.prepare_for_e2e_test.outputs.artemisAccountName }} (${{ needs.prepare_for_e2e_test.outputs.artemisAccountId }}). The following matrix container is being used ${{ matrix.containers }}"
+        run:
+          echo "Running E2E test for PR with title of ${{
+          inputs.external_pr_title || github.event.pull_request.title }} and
+          number being ${{ inputs.external_pr_number ||
+          github.event.pull_request.number }}. The following account will be
+          used ${{ needs.prepare_for_e2e_test.outputs.artemisAccountName }} (${{
+          needs.prepare_for_e2e_test.outputs.artemisAccountId }}). The following
+          matrix container is being used ${{ matrix.containers }}"
       - name: Log groupId
         run: echo "groupId - ${{ needs.create-shared-vars.outputs.groupId }}"
       - name: Log status of prepare_for_e2e_test job
@@ -378,8 +435,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.15.0
-          cache: "npm"
-          registry-url: "https://registry.npmjs.org"
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Cypress run
@@ -391,14 +448,20 @@ jobs:
           record: true
           parallel: true
           group: PR
-          ci-build-id: "${{ inputs.external_pr_sha || github.sha }}-${{ github.workflow }}-${{ github.event_name }}-${{ inputs.external_pr_number || github.event.pull_request.number }}"
+          ci-build-id:
+            '${{ inputs.external_pr_sha || github.sha }}-${{ github.workflow
+            }}-${{ github.event_name }}-${{ inputs.external_pr_number ||
+            github.event.pull_request.number }}'
           browser: chrome
-          tag: ${{ inputs.external_pr_repo_name || github.event.repository.name }},${{ github.event_name }}
+          tag:
+            ${{ inputs.external_pr_repo_name || github.event.repository.name
+            }},${{ github.event_name }}
         env:
           # https://github.com/cypress-io/cypress/issues/25357#issuecomment-1426992422
-          ELECTRON_EXTRA_LAUNCH_ARGS: "--disable-gpu"
+          ELECTRON_EXTRA_LAUNCH_ARGS: '--disable-gpu'
           CYPRESS_BROWSER: chrome
-          COMMIT_INFO_MESSAGE: ${{ inputs.external_pr_title || github.event.pull_request.title }}
+          COMMIT_INFO_MESSAGE:
+            ${{ inputs.external_pr_title || github.event.pull_request.title }}
           COMMIT_INFO_BRANCH: ${{ inputs.external_pr_branch }}
           COMMIT_INFO_AUTHOR: ${{ inputs.external_pr_author }}
           COMMIT_INFO_SHA: ${{ inputs.external_pr_sha }}
@@ -410,11 +473,14 @@ jobs:
           CYPRESS_ENVIRONMENT_NAME: jupiterone-dev
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          PR_NUMBER: ${{ inputs.external_pr_number || github.event.pull_request.number }}
-          REPO_NAME: ${{ inputs.external_pr_repo_name || github.event.repository.name }}
+          PR_NUMBER:
+            ${{ inputs.external_pr_number || github.event.pull_request.number }}
+          REPO_NAME:
+            ${{ inputs.external_pr_repo_name || github.event.repository.name }}
           SPEC: ${{ inputs.spec_to_run }}
           ACCOUNT: ${{ needs.prepare_for_e2e_test.outputs.artemisAccountName }}
-          ACCOUNT_SUBDOMAIN: ${{ needs.prepare_for_e2e_test.outputs.artemisAccountSubdomain }}
+          ACCOUNT_SUBDOMAIN:
+            ${{ needs.prepare_for_e2e_test.outputs.artemisAccountSubdomain }}
           ACCOUNT_ID: ${{ needs.prepare_for_e2e_test.outputs.artemisAccountId }}
           USERS: ${{ needs.prepare_for_e2e_test.outputs.artemisUsers }}
           TAGS: ${{ inputs.e2e_filter_tags }}
@@ -437,7 +503,7 @@ jobs:
         continue-on-error: ${{ inputs.e2e_pass_on_error }}
         with:
           authToken: ${{secrets.GITHUB_TOKEN}}
-          context: "E2E Test Status"
+          context: 'E2E Test Status'
           description: ${{ env.TEST_STATUS_DESCRIPTION }}
           state: ${{ env.TEST_STATUS_STATE }}
           sha: ${{github.event.pull_request.head.sha || github.sha}}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "singleQuote": true,
+  "proseWrap": "always",
+  "endOfLine": "lf"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,4 +15,3 @@ and this project adheres to
 - publish_integration_docker_image workflow
 - README for workflows
 - initial semver
-

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # .github
-For documentation on organization-wide GitHub workflows, please see [.github/workflows/README.md](https://github.com/JupiterOne/.github/blob/main/.github/workflows/README.md)
+
+For documentation on organization-wide GitHub workflows, please see
+[.github/workflows/README.md](https://github.com/JupiterOne/.github/blob/main/.github/workflows/README.md)

--- a/profile/README.md
+++ b/profile/README.md
@@ -4,10 +4,10 @@
 
 ## JupiterOne ❤️ Open Source Software
 
-Security is a basic right. The more accessible and effective we make security 
-technology to security practitioners, developers, 
-researchers, and students, the stronger that technology will grow and 
-ultimately, the safer our community will become.
+Security is a basic right. The more accessible and effective we make security
+technology to security practitioners, developers, researchers, and students, the
+stronger that technology will grow and ultimately, the safer our community will
+become.
 
 ## Resources
 

--- a/workflow-templates/octo-organization-ci.properties.json
+++ b/workflow-templates/octo-organization-ci.properties.json
@@ -1,13 +1,7 @@
 {
-    "name": "Octo Organization Workflow",
-    "description": "Octo Organization CI workflow template.",
-    "iconName": "example-icon",
-    "categories": [
-        "Go"
-    ],
-    "filePatterns": [
-        "package.json$",
-        "^Dockerfile",
-        ".*\\.md$"
-    ]
+  "name": "Octo Organization Workflow",
+  "description": "Octo Organization CI workflow template.",
+  "iconName": "example-icon",
+  "categories": ["Go"],
+  "filePatterns": ["package.json$", "^Dockerfile", ".*\\.md$"]
 }

--- a/workflow-templates/octo-organization-ci.yml
+++ b/workflow-templates/octo-organization-ci.yml
@@ -2,9 +2,9 @@ name: Octo Organization CI
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches: [$default-branch]
   pull_request:
-    branches: [ $default-branch ]
+    branches: [$default-branch]
 
 jobs:
   build:
@@ -15,4 +15,3 @@ jobs:
 
       - name: Run a one-line script
         run: echo Hello from JupiterOne
-


### PR DESCRIPTION
We assumed all FE repos would have Artemis installed. Artemis is a backend project, and adding it to a FE one adds a large number of dependence + false positive vulns. Better to just remote-pull Artemis and not require it as a direct dependency. 


Test Job:
https://github.com/JupiterOne/web-integrations/actions/runs/5695236859/job/15437969009?pr=466