### PR TITLE
composite-actions-fix

### DIFF
--- a/.github/workflows/docs/frontend/frontend_runtime_application_pr.md
+++ b/.github/workflows/docs/frontend/frontend_runtime_application_pr.md
@@ -20,6 +20,7 @@ This action requires uses the following inputs:
 | `e2e_artemis_config_path`   | String  | cypress/artemis-config.yaml  | False      | Used to determine the path to the artemis config file
 | `spec_to_run`               | String  | cypress/e2e/**/*.feature     | False      | Used to determine which test to run
 | `magic_url_route`           | String  | '/'                          | False      | The relative route the magic url should go to
+| `use_global_actions`        | String  | True                         | False      | Will leverage composite actions from the jupiterone/.github repo. If false, will look for the actions to exist locally which is useful for testing these actions locally.
                                                                            
 ## Secrets
 

--- a/.github/workflows/docs/frontend/frontend_runtime_deploy.md
+++ b/.github/workflows/docs/frontend/frontend_runtime_deploy.md
@@ -13,6 +13,7 @@ This action requires uses the following inputs:
 | --------------------------- | ------- | ---------------------------- | --------- | -------------------------------------------------------------------------------------- |
 | `fallback_runner`           | String  | False                        | False      | If true will leverage ubuntu-latest, otherwise will fall back to the J1 in-house runner
 | `publish_chromatic`         | Boolean | True                         | False      | If true, will publish to Chromatic
+| `use_global_actions`        | String  | True                         | False      | Will leverage composite actions from the jupiterone/.github repo. If false, will look for the actions to exist locally which is useful for testing these actions locally.
                                                                            
 ## Secrets
 

--- a/.github/workflows/docs/frontend/frontend_runtime_e2e_trigger_response.md
+++ b/.github/workflows/docs/frontend/frontend_runtime_e2e_trigger_response.md
@@ -16,6 +16,7 @@ This action requires uses the following inputs:
 | `external_pr_author`        | String  |                              | True      | Used by the e2e_trigger to give builds in Cypress the correct author name associated with the owner of the PR
 | `external_pr_sha`           | String  |                              | True      | Used by the e2e_trigger to pass in the PR number associated with the PR that triggered the flow
 | `external_pr_repo_name`     | String  |                              | True      | Used by the e2e_trigger to tag builds in Cypress with the appropriate repo name associated with the repo that triggered the flow
+| `use_global_actions`        | String  | True                         | False      | Will leverage composite actions from the jupiterone/.github repo. If false, will look for the actions to exist locally which is useful for testing these actions locally.
                                                                            
 ## Secrets
 

--- a/.github/workflows/docs/frontend/frontend_runtime_utility_pr.md
+++ b/.github/workflows/docs/frontend/frontend_runtime_utility_pr.md
@@ -15,6 +15,7 @@ This action requires uses the following inputs:
 | `use_e2e_trigger`           | Boolean | false                        | False      | Trigger E2E tests in other repos
 | `e2e_pass_on_error`         | Boolean | false                        | False      | Pass the workflow even if the E2E test fail
 | `repos_to_test`             | String  |                              | False      | The relative route the magic url should go to
+| `use_global_actions`        | String  | True                         | False      | Will leverage composite actions from the jupiterone/.github repo. If false, will look for the actions to exist locally which is useful for testing these actions locally.
                                                                            
 ## Secrets
 

--- a/.github/workflows/frontend_runtime_application_pr.yml
+++ b/.github/workflows/frontend_runtime_application_pr.yml
@@ -99,13 +99,13 @@ jobs:
     if: ${{ inputs.use_validate }}
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 2
-      - uses: actions/checkout@v3
         if: ${{ inputs.use_global_actions }}
         with:
           repository: jupiterone/.github
           sparse-checkout: .github/actions
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
       - name: validate
         uses: ./.github/actions/frontend/runtime/validate
 
@@ -114,13 +114,13 @@ jobs:
     if: ${{ inputs.use_chromatic }}
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: actions/checkout@v3
         if: ${{ !env.TEST }}
         with:
           repository: ${{ (inputs.use_global_actions && github.repository) || 'jupiterone/.github' }}
           sparse-checkout: .github/actions
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: chromatic_upload
         uses: ./.github/actions/frontend/runtime/chromatic
         with:
@@ -132,11 +132,11 @@ jobs:
     needs: [migration_number]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/checkout@v3
         if: ${{ inputs.use_global_actions }}
         with:
           repository: jupiterone/.github
           sparse-checkout: .github/actions
+      - uses: actions/checkout@v3
       - name: magic_url
         uses: ./.github/actions/frontend/runtime/magic_url
         with:
@@ -155,11 +155,11 @@ jobs:
       artemis_users: ${{ steps.e2e_prepare.outputs.artemis_users }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/checkout@v3
         if: ${{ inputs.use_global_actions }}
         with:
           repository: jupiterone/.github
           sparse-checkout: .github/actions
+      - uses: actions/checkout@v3
       - id: e2e_prepare
         name: e2e_prepare
         uses: ./.github/actions/frontend/runtime/e2e_prepare
@@ -188,11 +188,11 @@ jobs:
       test_passed: ${{ steps.e2e_run.outputs.test_passed }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/checkout@v3
         if: ${{ inputs.use_global_actions }}
         with:
           repository: jupiterone/.github
           sparse-checkout: .github/actions
+      - uses: actions/checkout@v3
       - id: e2e_run
         name: e2e_run
         uses: ./.github/actions/frontend/runtime/e2e_run
@@ -219,11 +219,11 @@ jobs:
     needs: [e2e_run]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/checkout@v3
         if: ${{ inputs.use_global_actions }}
         with:
           repository: jupiterone/.github
           sparse-checkout: .github/actions
+      - uses: actions/checkout@v3
       - name: e2e_status
         uses: ./.github/actions/frontend/runtime/e2e_status
         with:

--- a/.github/workflows/frontend_runtime_application_pr.yml
+++ b/.github/workflows/frontend_runtime_application_pr.yml
@@ -42,6 +42,10 @@ on:
         description: 'The relative route the magic url should go to'
         type: string
         default: '/'
+      use_global_actions:
+        description: "Will leverage composite actions from the jupiterone/.github repo. If false, will look for the actions to exist locally which is useful for testing these actions locally."
+        default: true
+        type: boolean
     secrets:
       NPM_TOKEN:
         description: "A J1 npm.com Publish token"
@@ -80,7 +84,12 @@ jobs:
     outputs:
       migration: ${{ steps.migration_number.outputs.migration }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        if: ${{ inputs.use_global_actions }}
+        with:
+          repository: jupiterone/.github
+          sparse-checkout: .github/actions
       - id: migration_number
         name: migration_number
         uses: ./.github/actions/frontend/runtime/migration_number
@@ -92,6 +101,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
+      - uses: actions/checkout@v3
+        if: ${{ inputs.use_global_actions }}
+        with:
+          repository: jupiterone/.github
+          sparse-checkout: .github/actions
       - name: validate
         uses: ./.github/actions/frontend/runtime/validate
 
@@ -102,6 +116,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - uses: actions/checkout@v3
+        if: ${{ !env.TEST }}
+        with:
+          repository: ${{ (inputs.use_global_actions && github.repository) || 'jupiterone/.github' }}
+          sparse-checkout: .github/actions
       - name: chromatic_upload
         uses: ./.github/actions/frontend/runtime/chromatic
         with:
@@ -112,7 +131,12 @@ jobs:
     runs-on: ${{ (inputs.fallback_runner && 'ubuntu-latest') || fromJson('["jupiterone-dev", "arm64"]') }}
     needs: [migration_number]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        if: ${{ inputs.use_global_actions }}
+        with:
+          repository: jupiterone/.github
+          sparse-checkout: .github/actions
       - name: magic_url
         uses: ./.github/actions/frontend/runtime/magic_url
         with:
@@ -130,7 +154,12 @@ jobs:
       artemis_account_subdomain: ${{ steps.e2e_prepare.outputs.artemis_account_subdomain }}
       artemis_users: ${{ steps.e2e_prepare.outputs.artemis_users }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        if: ${{ inputs.use_global_actions }}
+        with:
+          repository: jupiterone/.github
+          sparse-checkout: .github/actions
       - id: e2e_prepare
         name: e2e_prepare
         uses: ./.github/actions/frontend/runtime/e2e_prepare
@@ -158,7 +187,12 @@ jobs:
     outputs:
       test_passed: ${{ steps.e2e_run.outputs.test_passed }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        if: ${{ inputs.use_global_actions }}
+        with:
+          repository: jupiterone/.github
+          sparse-checkout: .github/actions
       - id: e2e_run
         name: e2e_run
         uses: ./.github/actions/frontend/runtime/e2e_run
@@ -184,7 +218,12 @@ jobs:
     runs-on: ${{ (inputs.fallback_runner && 'ubuntu-latest') || fromJson('["jupiterone-dev", "arm64"]') }}
     needs: [e2e_run]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        if: ${{ inputs.use_global_actions }}
+        with:
+          repository: jupiterone/.github
+          sparse-checkout: .github/actions
       - name: e2e_status
         uses: ./.github/actions/frontend/runtime/e2e_status
         with:

--- a/.github/workflows/frontend_runtime_deploy.yml
+++ b/.github/workflows/frontend_runtime_deploy.yml
@@ -10,6 +10,10 @@ on:
       publish_chromatic:
         description: "If true, will publish to Chromatic"
         type: boolean
+      use_global_actions:
+        description: "Will leverage composite actions from the jupiterone/.github repo. If false, will look for the actions to exist locally which is useful for testing these actions locally."
+        default: true
+        type: boolean
     secrets:
       NPM_TOKEN:
         description: "A J1 npm.com Publish token"
@@ -33,6 +37,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - uses: actions/checkout@v3
+        if: ${{ inputs.use_global_actions }}
+        with:
+          repository: jupiterone/.github
+          sparse-checkout: .github/actions
       - name: chromatic_publish
         uses: ./.github/actions/frontend/runtime/chromatic
         with:
@@ -43,7 +52,12 @@ jobs:
   cortex:
     runs-on: ${{ (inputs.fallback_runner && 'ubuntu-latest') || fromJson('["jupiterone-dev", "arm64"]') }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        if: ${{ inputs.use_global_actions }}
+        with:
+          repository: jupiterone/.github
+          sparse-checkout: .github/actions
       - name: cortex
         uses: ./.github/actions/frontend/cortex
         with:

--- a/.github/workflows/frontend_runtime_deploy.yml
+++ b/.github/workflows/frontend_runtime_deploy.yml
@@ -35,13 +35,13 @@ jobs:
     if: ${{ inputs.publish_chromatic }}
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: actions/checkout@v3
         if: ${{ inputs.use_global_actions }}
         with:
           repository: jupiterone/.github
           sparse-checkout: .github/actions
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: chromatic_publish
         uses: ./.github/actions/frontend/runtime/chromatic
         with:
@@ -53,11 +53,11 @@ jobs:
     runs-on: ${{ (inputs.fallback_runner && 'ubuntu-latest') || fromJson('["jupiterone-dev", "arm64"]') }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/checkout@v3
         if: ${{ inputs.use_global_actions }}
         with:
           repository: jupiterone/.github
           sparse-checkout: .github/actions
+      - uses: actions/checkout@v3
       - name: cortex
         uses: ./.github/actions/frontend/cortex
         with:

--- a/.github/workflows/frontend_runtime_e2e_trigger_response.yml
+++ b/.github/workflows/frontend_runtime_e2e_trigger_response.yml
@@ -76,11 +76,11 @@ jobs:
       migration: ${{ steps.migration_number.outputs.migration }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/checkout@v3
         if: ${{ inputs.use_global_actions }}
         with:
           repository: jupiterone/.github
           sparse-checkout: .github/actions
+      - uses: actions/checkout@v3
       - id: migration_number
         name: migration_number
         uses: ./.github/actions/frontend/runtime/migration_number
@@ -95,11 +95,11 @@ jobs:
       artemis_users: ${{ steps.e2e_prepare.outputs.artemis_users }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/checkout@v3
         if: ${{ inputs.use_global_actions }}
         with:
           repository: jupiterone/.github
           sparse-checkout: .github/actions
+      - uses: actions/checkout@v3
       - id: e2e_prepare
         name: e2e_prepare
         uses: ./.github/actions/frontend/runtime/e2e_prepare
@@ -119,11 +119,11 @@ jobs:
       test_passed: ${{ steps.e2e_run.outputs.test_passed }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/checkout@v3
         if: ${{ inputs.use_global_actions }}
         with:
           repository: jupiterone/.github
           sparse-checkout: .github/actions
+      - uses: actions/checkout@v3
       - id: e2e_run
         name: e2e_run
         uses: ./.github/actions/frontend/runtime/e2e_run

--- a/.github/workflows/frontend_runtime_e2e_trigger_response.yml
+++ b/.github/workflows/frontend_runtime_e2e_trigger_response.yml
@@ -36,6 +36,10 @@ on:
         description: 'Used by the e2e_trigger to tag builds in Cypress with the appropriate repo name associated with the repo that triggered the flow'
         type: string
         required: true
+      use_global_actions:
+        description: "Will leverage composite actions from the jupiterone/.github repo. If false, will look for the actions to exist locally which is useful for testing these actions locally."
+        default: true
+        type: boolean
     secrets:
       NPM_TOKEN:
         description: "A J1 npm.com Publish token"
@@ -71,7 +75,12 @@ jobs:
     outputs:
       migration: ${{ steps.migration_number.outputs.migration }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        if: ${{ inputs.use_global_actions }}
+        with:
+          repository: jupiterone/.github
+          sparse-checkout: .github/actions
       - id: migration_number
         name: migration_number
         uses: ./.github/actions/frontend/runtime/migration_number
@@ -85,7 +94,12 @@ jobs:
       artemis_account_subdomain: ${{ steps.e2e_prepare.outputs.artemis_account_subdomain }}
       artemis_users: ${{ steps.e2e_prepare.outputs.artemis_users }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        if: ${{ inputs.use_global_actions }}
+        with:
+          repository: jupiterone/.github
+          sparse-checkout: .github/actions
       - id: e2e_prepare
         name: e2e_prepare
         uses: ./.github/actions/frontend/runtime/e2e_prepare
@@ -104,7 +118,12 @@ jobs:
     outputs:
       test_passed: ${{ steps.e2e_run.outputs.test_passed }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        if: ${{ inputs.use_global_actions }}
+        with:
+          repository: jupiterone/.github
+          sparse-checkout: .github/actions
       - id: e2e_run
         name: e2e_run
         uses: ./.github/actions/frontend/runtime/e2e_run

--- a/.github/workflows/frontend_runtime_utility_pr.yml
+++ b/.github/workflows/frontend_runtime_utility_pr.yml
@@ -63,11 +63,11 @@ jobs:
       migration: ${{ steps.migration_number.outputs.migration }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/checkout@v3
         if: ${{ inputs.use_global_actions }}
         with:
           repository: jupiterone/.github
           sparse-checkout: .github/actions
+      - uses: actions/checkout@v3
       - id: migration_number
         name: migration_number
         uses: ./.github/actions/frontend/runtime/migration_number
@@ -77,13 +77,13 @@ jobs:
     if: ${{ inputs.use_validate }}
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 2
-      - uses: actions/checkout@v3
         if: ${{ inputs.use_global_actions }}
         with:
           repository: jupiterone/.github
           sparse-checkout: .github/actions
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
       - name: validate
         uses: ./.github/actions/frontend/runtime/validate
 
@@ -92,13 +92,13 @@ jobs:
     if: ${{ inputs.use_chromatic }}
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: actions/checkout@v3
         if: ${{ inputs.use_global_actions }}
         with:
           repository: jupiterone/.github
           sparse-checkout: .github/actions
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: chromatic_upload
         uses: ./.github/actions/frontend/runtime/chromatic
         with:
@@ -110,11 +110,11 @@ jobs:
     needs: [migration_number]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/checkout@v3
         if: ${{ inputs.use_global_actions }}
         with:
           repository: jupiterone/.github
           sparse-checkout: .github/actions
+      - uses: actions/checkout@v3
       - name: magic_url
         uses: ./.github/actions/frontend/runtime/magic_url
         with:
@@ -135,11 +135,11 @@ jobs:
       test_passed: ${{ steps.e2e_trigger_remote_tests.outputs.test_passed }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/checkout@v3
         if: ${{ inputs.use_global_actions }}
         with:
           repository: jupiterone/.github
           sparse-checkout: .github/actions
+      - uses: actions/checkout@v3
       - id: e2e_trigger_remote_tests
         name: e2e_trigger_remote_tests
         uses: ./.github/actions/frontend/runtime/e2e_trigger_remote_tests
@@ -156,11 +156,11 @@ jobs:
     needs: [e2e_trigger_remote_tests]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/checkout@v3
         if: ${{ inputs.use_global_actions }}
         with:
           repository: jupiterone/.github
           sparse-checkout: .github/actions
+      - uses: actions/checkout@v3
       - name: e2e_status
         uses: ./.github/actions/frontend/runtime/e2e_status
         with:

--- a/.github/workflows/frontend_runtime_utility_pr.yml
+++ b/.github/workflows/frontend_runtime_utility_pr.yml
@@ -26,6 +26,10 @@ on:
       repos_to_test:
         description: "Kick off a n+ spec files within n+ repos"
         type: string
+      use_global_actions:
+        description: "Will leverage composite actions from the jupiterone/.github repo. If false, will look for the actions to exist locally which is useful for testing these actions locally."
+        default: true
+        type: boolean
     secrets:
       NPM_TOKEN:
         description: "A J1 npm.com Publish token"
@@ -58,7 +62,12 @@ jobs:
     outputs:
       migration: ${{ steps.migration_number.outputs.migration }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        if: ${{ inputs.use_global_actions }}
+        with:
+          repository: jupiterone/.github
+          sparse-checkout: .github/actions
       - id: migration_number
         name: migration_number
         uses: ./.github/actions/frontend/runtime/migration_number
@@ -67,9 +76,14 @@ jobs:
     runs-on: ${{ (inputs.fallback_runner && 'ubuntu-latest') || fromJson('["jupiterone-dev", "arm64"]') }}
     if: ${{ inputs.use_validate }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 2
+      - uses: actions/checkout@v3
+        if: ${{ inputs.use_global_actions }}
+        with:
+          repository: jupiterone/.github
+          sparse-checkout: .github/actions
       - name: validate
         uses: ./.github/actions/frontend/runtime/validate
 
@@ -80,6 +94,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - uses: actions/checkout@v3
+        if: ${{ inputs.use_global_actions }}
+        with:
+          repository: jupiterone/.github
+          sparse-checkout: .github/actions
       - name: chromatic_upload
         uses: ./.github/actions/frontend/runtime/chromatic
         with:
@@ -90,7 +109,12 @@ jobs:
     runs-on: ${{ (inputs.fallback_runner && 'ubuntu-latest') || fromJson('["jupiterone-dev", "arm64"]') }}
     needs: [migration_number]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        if: ${{ inputs.use_global_actions }}
+        with:
+          repository: jupiterone/.github
+          sparse-checkout: .github/actions
       - name: magic_url
         uses: ./.github/actions/frontend/runtime/magic_url
         with:
@@ -110,7 +134,12 @@ jobs:
     outputs:
       test_passed: ${{ steps.e2e_trigger_remote_tests.outputs.test_passed }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        if: ${{ inputs.use_global_actions }}
+        with:
+          repository: jupiterone/.github
+          sparse-checkout: .github/actions
       - id: e2e_trigger_remote_tests
         name: e2e_trigger_remote_tests
         uses: ./.github/actions/frontend/runtime/e2e_trigger_remote_tests
@@ -126,7 +155,12 @@ jobs:
     runs-on: ${{ (inputs.fallback_runner && 'ubuntu-latest') || fromJson('["jupiterone-dev", "arm64"]') }}
     needs: [e2e_trigger_remote_tests]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        if: ${{ inputs.use_global_actions }}
+        with:
+          repository: jupiterone/.github
+          sparse-checkout: .github/actions
       - name: e2e_status
         uses: ./.github/actions/frontend/runtime/e2e_status
         with:

--- a/README.md
+++ b/README.md
@@ -35,9 +35,6 @@ The workflows above take advantage of the composite actions listed below, levera
 When using composite actions, you will need to perform the following checkouts:
 
 ```
-# Checks out the repository where the workflow is being run
-- uses: actions/checkout@v3
-
 # Checks out the global repository where the composite actions live (jupiterone/.github),
 # without this, the composite action will not be found as each job is run in virtual container:
 - uses: actions/checkout@v3
@@ -45,6 +42,9 @@ When using composite actions, you will need to perform the following checkouts:
   with:
     repository: jupiterone/.github
     sparse-checkout: .github/actions
+
+# Checks out the repository where the workflow is being run
+- uses: actions/checkout@v3
 
 # You can now use the composite action
 - name: some_composite_action

--- a/README.md
+++ b/README.md
@@ -30,6 +30,27 @@ The workflows above take advantage of the composite actions listed below, levera
 - [migration_number](.github/actions/frontend/runtime/migration_number/README.md)
 - [validate](.github/actions/frontend/runtime/validate/README.md)
 
+### 
+
+When using composite actions, you will need to perform the following checkouts:
+
+```
+# Checks out the repository where the workflow is being run
+- uses: actions/checkout@v3
+
+# Checks out the global repository where the composite actions live (jupiterone/.github),
+# without this, the composite action will not be found as each job is run in virtual container:
+- uses: actions/checkout@v3
+  if: ${{ inputs.use_global_actions }}
+  with:
+    repository: jupiterone/.github
+    sparse-checkout: .github/actions
+
+# You can now use the composite action
+- name: some_composite_action
+  uses: ./.github/actions/some_composite_action
+```
+
 ## Local Testing
 
 We are using [act-js](https://github.com/kiegroup/act-js) and [mock-github](https://www.npmjs.com/package/@kie/mock-github#mockgithub) to test our workflows and composite actions. These tests are intended to simplify development, speed up the feedback loop, and bring more stability to our flows and actions. To run the tests, please execute the following command:

--- a/tests/utils/setup.ts
+++ b/tests/utils/setup.ts
@@ -81,7 +81,7 @@ export const runCompositeAction = async ({
   // If true, will skip all steps in the composite action that contain "if: ${{ !env.TEST }}"
   act.setEnv('TEST', String(mockSteps));
 
-  const result = await act.runEventAndJob('push', repoName, { logFile: process.env.ACT_LOG ? `repo/${repoName}.log` : undefined });
+  const result = await act.runEventAndJob('push', repoName, { logFile: process.env.ACT_LOG ? `${repoName}.log` : undefined });
   
   /*
   The first two and last item in the returned results are the same for every composite action test.
@@ -108,8 +108,11 @@ export const runWorkflow = async ({
 
   // Need to leverage ubuntu-latest for tests to operate
   act.setInput('fallback_runner', 'true');
+
+  // Ensures we're not attempting to checkout the global repository in our tests as we're already in it
+  act.setInput('use_global_actions', 'false');
   
-  const result = await act.runEvent('workflow_call', { logFile: process.env.ACT_LOG ? `repo/${repoName}.log` : undefined, ...config });
+  const result = await act.runEvent('workflow_call', { logFile: process.env.ACT_LOG ? `${repoName}.log` : undefined, ...config });
 
   return result;
 };


### PR DESCRIPTION
This PR addresses an issue where the composite actions are currently not being found in the workflows. When using composite actions, we have to perform the following checkouts:

```
# Checks out the global repository where the composite actions live (jupiterone/.github),
# without this, the composite action will not be found as each job is run in virtual container:
- uses: actions/checkout@v3
  if: ${{ inputs.use_global_actions }}
  with:
    repository: jupiterone/.github
    sparse-checkout: .github/actions

# Checks out the repository where the workflow is being run
- uses: actions/checkout@v3

# You can now use the composite action
- name: some_composite_action
  uses: ./.github/actions/some_composite_action
```