### PR TITLE
fix-trigger

### DIFF
--- a/.github/workflows/frontend_runtime_e2e_trigger_response.yml
+++ b/.github/workflows/frontend_runtime_e2e_trigger_response.yml
@@ -49,6 +49,9 @@ on:
       CYPRESS_PASSWORD:
         description: "The password of the E2E username"
         required: false
+      DOCKER_HUB_SRE:
+        description: "The password to login to docker hub sre"
+        # required: true
 
 env:
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -96,7 +99,13 @@ jobs:
   e2e_run:
     # Note this is the only job that leverages amd64
     runs-on: ${{ (inputs.fallback_runner && 'ubuntu-latest') || 'scaleset-jupiterone-infra-amd64' }}
-    container: cypress/browsers:node18.12.0-chrome106-ff106
+    container:
+      # Available containers here: https://hub.docker.com/r/cypress/browsers/tags
+      image: cypress/browsers:latest
+      options: --user 1001
+      # credentials:
+        # username: jupiteronesre
+        # password: ${{ secrets.DOCKER_HUB_SRE }}
     permissions: write-all
     timeout-minutes: 25
     needs: [migration_number, e2e_prepare]

--- a/.github/workflows/frontend_runtime_e2e_trigger_response.yml
+++ b/.github/workflows/frontend_runtime_e2e_trigger_response.yml
@@ -107,7 +107,6 @@ jobs:
         # username: jupiteronesre
         # password: ${{ secrets.DOCKER_HUB_SRE }}
     permissions: write-all
-    timeout-minutes: 25
     needs: [migration_number, e2e_prepare]
     strategy:
       # when one test fails, DO NOT cancel the other containers, because this will kill Cypress processes
@@ -124,6 +123,7 @@ jobs:
       - id: e2e_run
         name: e2e_run
         uses: jupiterone/.github/.github/actions/frontend/runtime/e2e_run@v2
+        timeout-minutes: 120
         with:
           artemis_account_name: ${{ needs.e2e_prepare.outputs.artemis_account_name }}
           artemis_account_id: ${{ needs.e2e_prepare.outputs.artemis_account_id }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "github workflows",
-  "version": "1.0.0",
+  "name": ".github",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "github workflows",
-      "version": "1.0.0",
+      "name": ".github",
+      "version": "0.0.0",
       "license": "UNLICENSED",
       "devDependencies": {
         "@kie/act-js": "^2.2.1",


### PR DESCRIPTION
While we updated the image for the e2e_run in the [application PR flow](https://github.com/JupiterOne/.github/blob/50081cf55deab1e0ec051078cc496ffb1195d77a/.github/workflows/frontend_runtime_application_pr.yml#L192), we never updated it for the trigger response. The old image (`cypress/browsers:node18.12.0-chrome106-ff106`) is not compatible with our new runners.