### PR TITLE
fix-build-id

### DIFF
--- a/.github/actions/frontend/runtime/e2e_run/action.yml
+++ b/.github/actions/frontend/runtime/e2e_run/action.yml
@@ -77,6 +77,9 @@ inputs:
     description: 'Cancel the tests after this many failures'
     default: 2
     type: number
+  ci_build_id:
+    description: 'Used to link separate machines running tests into a single parallel run'
+    required: true
 
 outputs:
   test_passed:
@@ -88,6 +91,7 @@ runs:
     - name: e2e_run_inputs
       shell: bash
       run: |
+        echo "ci_build_id=${{ inputs.ci_build_id }}"
         echo "artemis_account_name=${{ inputs.artemis_account_name }}"
         echo "artemis_account_id=${{ inputs.artemis_account_id }}"
         echo "artemis_account_subdomain=${{ inputs.artemis_account_subdomain }}"
@@ -124,7 +128,8 @@ runs:
         record: true
         parallel: true
         group: PR
-        ci-build-id: "${{ inputs.commit_info_sha || github.sha }}-${{ github.workflow }}-${{ github.event_name }}-${{ inputs.commit_info_pr_title || github.event.pull_request.title }}"
+        # It's important this is unique to the commit/repo this is running against
+        ci-build-id: ${{ inputs.ci_build_id }}
         browser: chrome
         tag: ${{ inputs.commit_info_repo_name || github.event.repository.name }},${{ github.event_name }}
       env:

--- a/.github/actions/unique_id/README.md
+++ b/.github/actions/unique_id/README.md
@@ -1,0 +1,25 @@
+# PR Comment
+
+This [composite action](./action.yml) is responsible for leaving a comment on a PR. By default it will only leave a comment once of the same message (i.e. no duplicates), however this can be overridden.
+
+## Inputs
+
+This action takes the following inputs:
+
+| Name                        | Type    | Default                      | Required  | Description                                               |
+| --------------------------- | ------- | ---------------------------- | --------- | --------------------------------------------------------- |
+| `message`                   | String  |                              | True      | The message to leave in the PR comment
+| `run_once`                  | Boolean | True                         | False     | Determines whether to leave one comment or add one on each call
+                                                                           
+## Outputs
+
+No outputs provided.                                                  
+
+## Example Usage
+
+```yaml
+- name: pr_comment
+  uses: jupiterone/.github/.github/actions/pr_comment
+  with:
+    message: Custom message goes here
+```

--- a/.github/actions/unique_id/README.md
+++ b/.github/actions/unique_id/README.md
@@ -1,6 +1,6 @@
-# PR Comment
+# Unique ID
 
-This [composite action](./action.yml) is responsible for leaving a comment on a PR. By default it will only leave a comment once of the same message (i.e. no duplicates), however this can be overridden.
+This [composite action](./action.yml) is responsible for generating a unique ID using a timestamp and the current commit SHA.
 
 ## Inputs
 
@@ -8,18 +8,21 @@ This action takes the following inputs:
 
 | Name                        | Type    | Default                      | Required  | Description                                               |
 | --------------------------- | ------- | ---------------------------- | --------- | --------------------------------------------------------- |
-| `message`                   | String  |                              | True      | The message to leave in the PR comment
-| `run_once`                  | Boolean | True                         | False     | Determines whether to leave one comment or add one on each call
+| `sha`                       | String  |                              | True      | The github.sha which is the SHA for a temporary commit created for validating the pull request
                                                                            
 ## Outputs
 
-No outputs provided.                                                  
+This action returns the following outputs:
+
+| Name                        | Type    | Description                                               |
+| --------------------------- | ------- | --------------------------------------------------------- |
+| `unique_id`                 | String  | An ID that is unique to both the repo and commit                                          
 
 ## Example Usage
 
 ```yaml
 - name: pr_comment
-  uses: jupiterone/.github/.github/actions/pr_comment
+  uses: jupiterone/.github/.github/actions/unique_id
   with:
-    message: Custom message goes here
+    sha: Custom message goes here
 ```

--- a/.github/actions/unique_id/README.md
+++ b/.github/actions/unique_id/README.md
@@ -21,8 +21,12 @@ This action returns the following outputs:
 ## Example Usage
 
 ```yaml
-- name: pr_comment
-  uses: jupiterone/.github/.github/actions/unique_id
-  with:
-    sha: Custom message goes here
+steps:
+  - name: unique_id
+    uses: jupiterone/.github/.github/actions/unique_id
+    with:
+      sha: ${{ github.sha }}
+  - name: echo_unique_id
+    run: |
+      echo ${{ steps.unique_id.outputs.unique_id }}
 ```

--- a/.github/actions/unique_id/action.yml
+++ b/.github/actions/unique_id/action.yml
@@ -3,6 +3,7 @@ name: Returns a unique ID
 inputs:
   sha:
     type: string
+    description: 'The github.sha which is the SHA for a temporary commit created for validating the pull request'
     required: true
 
 outputs:
@@ -15,7 +16,6 @@ runs:
     - name: unique_id
       id: unique_id
       shell: bash
-      run: echo "value=$(date +"%s")" >> $GITHUB_OUTPUT
       # take the current commit + timestamp together
       # the typical value would be something like
       # "sha-5d3fe...35d3-time-1620841214"

--- a/.github/actions/unique_id/action.yml
+++ b/.github/actions/unique_id/action.yml
@@ -1,0 +1,22 @@
+name: Returns a unique ID
+
+inputs:
+  sha:
+    type: string
+    required: true
+
+outputs:
+  unique_id:
+    value: ${{ steps.unique_id.outputs.value }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: unique_id
+      id: unique_id
+      shell: bash
+      run: echo "value=$(date +"%s")" >> $GITHUB_OUTPUT
+      # take the current commit + timestamp together
+      # the typical value would be something like
+      # "sha-5d3fe...35d3-time-1620841214"
+      run: echo "value=sha-${{ inputs.sha }}-time-$(date +"%s")" >> $GITHUB_OUTPUT

--- a/.github/workflows/docs/frontend/frontend_runtime_application_manual_e2e_run.md
+++ b/.github/workflows/docs/frontend/frontend_runtime_application_manual_e2e_run.md
@@ -78,16 +78,18 @@ graph TD;
     D[migration_number];
     E[e2e_prepare];
     F[magic_url];
-    G[e2e_run];
-    H[e2e_status];
+    G[unique_id];
+    H[e2e_run];
+    I[e2e_status];
 
     A --> B;
     B --> D;
     B --> E;
     B --> C;
     D --> F;
-    F --> G;
+    F --> H;
     G --> H;
-    C --> H;
+    H --> I;
+    C --> I;
     E --> G;
 ```

--- a/.github/workflows/docs/frontend/frontend_runtime_utility_manual_e2e_trigger.md
+++ b/.github/workflows/docs/frontend/frontend_runtime_utility_manual_e2e_trigger.md
@@ -79,10 +79,12 @@ graph LR;
     C[e2e_pending_status];
     D[migration_number];
     E[magic_url];
-    F[e2e_trigger_remote_tests];
-    G[external_repo];
-    H[e2e_status];
+    F[unique_id];
+    G[e2e_trigger_remote_tests];
+    H[external_repo];
+    I[e2e_status];
 
-    A --> B --> C --> E --> F --> G -->|trigger E2E tests and wait| H -->|report back status| G --> H;
+    A --> B --> C --> E --> G --> H -->|trigger E2E tests and wait| I -->|report back status| H --> I;
     B --> D --> E;
+    F --> G;
 ```

--- a/.github/workflows/frontend_runtime_application_manual_e2e_run.yml
+++ b/.github/workflows/frontend_runtime_application_manual_e2e_run.yml
@@ -148,6 +148,21 @@ jobs:
           e2e_artemis_config_path: ${{ inputs.e2e_artemis_config_path }}
           user_count: $(echo '${{ inputs.e2e_containers }}' | jq '. | length')
 
+  unique_id:
+    runs-on: ${{ (inputs.fallback_runner && 'ubuntu-latest') || 'scaleset-jupiterone-infra-arm64' }}
+    needs: [get_branch]
+    outputs:
+      unique_id: ${{ steps.unique_id.outputs.unique_id }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.get_branch.outputs.name }}
+      - id: unique_id
+        name: unique_id
+        uses: jupiterone/.github/.github/actions/unique_id@v3
+        with:
+          sha: ${{ github.sha }}
+
   e2e_run:
     # Note this is the only job that leverages amd64
     runs-on: ${{ (inputs.fallback_runner && 'ubuntu-latest') || 'scaleset-jupiterone-infra-amd64' }}
@@ -160,7 +175,7 @@ jobs:
         password: ${{ secrets.DOCKER_HUB_SRE }}
     continue-on-error: ${{ inputs.e2e_pass_on_error }}
     permissions: write-all
-    needs: [get_branch, e2e_prepare, migration_number, magic_url]
+    needs: [get_branch, e2e_prepare, migration_number, magic_url, unique_id]
     strategy:
       # when one test fails, DO NOT cancel the other containers, because this will kill Cypress processes
       # leaving Cypress Cloud hanging: https://github.com/cypress-io/github-action/issues/48 
@@ -181,6 +196,7 @@ jobs:
         uses: jupiterone/.github/.github/actions/frontend/runtime/e2e_run@v3
         timeout-minutes: 120
         with:
+          ci_build_id: ${{ needs.unique_id.outputs.unique_id }}
           artemis_account_name: ${{ needs.e2e_prepare.outputs.artemis_account_name }}
           artemis_account_id: ${{ needs.e2e_prepare.outputs.artemis_account_id }}
           artemis_account_subdomain: ${{ needs.e2e_prepare.outputs.artemis_account_subdomain }}

--- a/.github/workflows/frontend_runtime_e2e_trigger_response.yml
+++ b/.github/workflows/frontend_runtime_e2e_trigger_response.yml
@@ -106,7 +106,7 @@ jobs:
         name: unique_id
         uses: jupiterone/.github/.github/actions/unique_id@v3
         with:
-          sha: ${{ github.sha }}
+          sha: ${{ inputs.external_pr_sha }}
 
   e2e_run:
     # Note this is the only job that leverages amd64

--- a/.github/workflows/frontend_runtime_e2e_trigger_response.yml
+++ b/.github/workflows/frontend_runtime_e2e_trigger_response.yml
@@ -96,6 +96,18 @@ jobs:
         name: e2e_prepare
         uses: jupiterone/.github/.github/actions/frontend/runtime/e2e_prepare@v3
 
+  unique_id:
+    runs-on: ${{ (inputs.fallback_runner && 'ubuntu-latest') || 'scaleset-jupiterone-infra-arm64' }}
+    outputs:
+      unique_id: ${{ steps.unique_id.outputs.unique_id }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: unique_id
+        name: unique_id
+        uses: jupiterone/.github/.github/actions/unique_id@v3
+        with:
+          sha: ${{ github.sha }}
+
   e2e_run:
     # Note this is the only job that leverages amd64
     runs-on: ${{ (inputs.fallback_runner && 'ubuntu-latest') || 'scaleset-jupiterone-infra-amd64' }}
@@ -107,7 +119,7 @@ jobs:
         username: jupiteronesre
         password: ${{ secrets.DOCKER_HUB_SRE }}
     permissions: write-all
-    needs: [migration_number, e2e_prepare]
+    needs: [migration_number, e2e_prepare, unique_id]
     strategy:
       # when one test fails, DO NOT cancel the other containers, because this will kill Cypress processes
       # leaving Cypress Cloud hanging: https://github.com/cypress-io/github-action/issues/48 
@@ -125,6 +137,7 @@ jobs:
         uses: jupiterone/.github/.github/actions/frontend/runtime/e2e_run@v3
         timeout-minutes: 120
         with:
+          ci_build_id: ${{ needs.unique_id.outputs.unique_id }}
           artemis_account_name: ${{ needs.e2e_prepare.outputs.artemis_account_name }}
           artemis_account_id: ${{ needs.e2e_prepare.outputs.artemis_account_id }}
           artemis_account_subdomain: ${{ needs.e2e_prepare.outputs.artemis_account_subdomain }}

--- a/.github/workflows/test/frontend_runtime_application_manual_e2e_run.test.ts
+++ b/.github/workflows/test/frontend_runtime_application_manual_e2e_run.test.ts
@@ -109,9 +109,10 @@ test('flow with e2e_pass_on_error set to true to make tests non blocking', async
     'migration_number',
     'magic_url',
     'e2e_prepare',
+    'unique_id',
     'e2e_run',
     'e2e_status'
   ] });
 
-  expect(jobs_found.length).toEqual(6);
+  expect(jobs_found.length).toEqual(7);
 });

--- a/.github/workflows/test/frontend_runtime_e2e_trigger_response.test.ts
+++ b/.github/workflows/test/frontend_runtime_e2e_trigger_response.test.ts
@@ -90,8 +90,9 @@ test('default flow', async () => {
   const jobs_found = getTestResults({ results, names: [
     'migration_number',
     'e2e_prepare',
+    'unique_id',
     'e2e_run'
   ] });
 
-  expect(jobs_found.length).toEqual(3);
+  expect(jobs_found.length).toEqual(4);
 });


### PR DESCRIPTION
We keep experiencing issues with the [ci-build-id](https://currents.dev/readme/guides/cypress-ci-build-id) in our test runs. We must ensure this ID is unique, otherwise our e2e run will be notified by Cypress that the job was already run and therefore no tests will be executed in Cypress cloud. We are now employing the [following approach](https://github.com/cypress-io/github-action/blob/master/.github/workflows/example-custom-ci-build-id.yml) to ensure this ID is unique for every commit/run.