### PR TITLE
provision-only-update

### DIFF
--- a/.github/workflows/docs/provision_only_release.md
+++ b/.github/workflows/docs/provision_only_release.md
@@ -27,7 +27,7 @@ This action takes the following secrets:
 
 ```yaml
 jobs:
-  pr:
+  release:
     uses: jupiterone/.github/.github/workflows/provision_only_release.yml@v#
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/provision_only_pr.yml
+++ b/.github/workflows/provision_only_pr.yml
@@ -32,6 +32,7 @@ jobs:
         uses: jupiterone/.github/.github/actions/setup_env@v3
         with:
           use_dev: true
+      - uses: hashicorp/setup-terraform@v2
       - name: validate
         uses: jupiterone/.github/.github/actions/validate@v3
   

--- a/.github/workflows/provision_only_release.yml
+++ b/.github/workflows/provision_only_release.yml
@@ -35,6 +35,7 @@ jobs:
         uses: jupiterone/.github/.github/actions/setup_env@v3
         with:
           use_dev: true
+      - uses: hashicorp/setup-terraform@v2
       - name: validate
         uses: jupiterone/.github/.github/actions/validate@v3
   


### PR DESCRIPTION
Adds the `hashicorp/setup-terraform` action before the validation job to ensure terraform is installed.