### PR TITLE
SRE-1339 - add Backend Deployment Workflow

### DIFF
--- a/.github/actions/setup_env/action.yml
+++ b/.github/actions/setup_env/action.yml
@@ -1,35 +1,49 @@
-name: This action is responsible for setting up the environment, configuring node and installing the necessary dependencies
+name: Setup node, npm, and install npm dependencies
+description: |
+  This action is responsible for setting up the environment, configuring node
+  and installing the necessary dependencies
 
 inputs:
   use_dev:
     description: 'If true, will install dev dependencies.'
     required: false
-    type: boolean
-    default: false
+    default: 'false'
+  npm-install:
+    description: 'If true, will run npm install.'
+    required: false
+    default: 'true'
+  NODE_AUTH_TOKEN:
+    description: 'The auth token to use for npm.'
+    required: false
 
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - name: check_for_auth_token
-      if: ${{ env.NODE_AUTH_TOKEN == '' }}
+      if: ${{ env.NODE_AUTH_TOKEN == '' && inputs.NODE_AUTH_TOKEN == '' }}
       shell: bash
       run: |
-        echo "the secret \"NODE_AUTH_TOKEN\" has not been set"
-        exit 1
+        echo "the secret \"NODE_AUTH_TOKEN\" has not been set, this may cause issues with npm installs"
     - name: setup_node
       uses: actions/setup-node@v4
       with:
         cache: 'npm'
         registry-url: 'https://registry.npmjs.org'
     - name: npm_install_prod_deps
-      if: ${{ fromJSON(inputs.use_dev) }}
+      if: ${{ fromJSON(inputs.use_dev) && fromJSON(inputs.npm-install) }}
       run: npm ci --ignore-scripts
       shell: bash
+      env:
+        NODE_AUTH_TOKEN: ${{ env.NODE_AUTH_TOKEN || inputs.NODE_AUTH_TOKEN }}
     - name: npm_install_prod_and_dev_deps
-      if: ${{ !fromJSON(inputs.use_dev)}}
+      if: ${{ !fromJSON(inputs.use_dev) && fromJSON(inputs.npm-install) }}
       run: npm ci --ignore-scripts --omit=dev
       shell: bash
+      env:
+        NODE_AUTH_TOKEN: ${{ env.NODE_AUTH_TOKEN || inputs.NODE_AUTH_TOKEN }}
     - name: npm_rebuild
+      if: ${{ fromJSON(inputs.npm-install) }}
       run: npm rebuild && npm run prepare --if-present
       shell: bash
-
+      env:
+        NODE_AUTH_TOKEN: ${{ env.NODE_AUTH_TOKEN || inputs.NODE_AUTH_TOKEN }}

--- a/.github/actions/setup_env/action.yml
+++ b/.github/actions/setup_env/action.yml
@@ -12,7 +12,7 @@ inputs:
     description: 'If true, will run npm install.'
     required: false
     default: 'true'
-  NODE_AUTH_TOKEN:
+  node-auth-token:
     description: 'The auth token to use for npm.'
     required: false
 
@@ -34,16 +34,16 @@ runs:
       run: npm ci --ignore-scripts
       shell: bash
       env:
-        NODE_AUTH_TOKEN: ${{ env.NODE_AUTH_TOKEN || inputs.NODE_AUTH_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ env.NODE_AUTH_TOKEN || inputs.node-auth-token }}
     - name: npm_install_prod_and_dev_deps
       if: ${{ !fromJSON(inputs.use_dev) && fromJSON(inputs.npm-install) }}
       run: npm ci --ignore-scripts --omit=dev
       shell: bash
       env:
-        NODE_AUTH_TOKEN: ${{ env.NODE_AUTH_TOKEN || inputs.NODE_AUTH_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ env.NODE_AUTH_TOKEN || inputs.node-auth-token }}
     - name: npm_rebuild
       if: ${{ fromJSON(inputs.npm-install) }}
       run: npm rebuild && npm run prepare --if-present
       shell: bash
       env:
-        NODE_AUTH_TOKEN: ${{ env.NODE_AUTH_TOKEN || inputs.NODE_AUTH_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ env.NODE_AUTH_TOKEN || inputs.node-auth-token }}

--- a/.github/workflows/backend_deployment_pr.yaml
+++ b/.github/workflows/backend_deployment_pr.yaml
@@ -1,0 +1,62 @@
+name: 'Backend Deployment Workflow'
+
+on:
+  workflow_call:
+    inputs:
+      use-npm:
+        description: 'Run `npm ci`'
+        default: true
+        type: boolean
+      use-build:
+        description: 'Run `npm run build`'
+        default: true
+        type: boolean
+      setup-terraform:
+        description: 'Install terraform binaries'
+        default: false
+        type: boolean
+      language:
+        description: 'The language to use for code scanning'
+        default: 'javascript'
+        type: string
+    secrets:
+      NODE_AUTH_TOKEN:
+        description: 'A J1 npm.com Publish token'
+        required: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: scaleset-jupiterone-infra-arm64
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Jupiterone/.github/.github/actions/setup_env@v3.0.38
+        with:
+          use_dev: true
+          npm-install: ${{ inputs.use-npm }}
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+      # Some validations require terraform
+      - if: ${{ inputs.setup-terraform }}
+        uses: hashicorp/setup-terraform@v2
+      # Validation is required for all deployments
+      - run: npm run validate:ci
+      # Not all deployments build code
+      - if: ${{ inputs.use-build }}
+        run: npm run build
+  security:
+    name: Security
+    runs-on: scaleset-jupiterone-infra-amd64
+    permissions:
+      actions: read
+      security-events: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+      - name: security
+        uses: jupiterone/.github/.github/actions/code_ql@v3.0.38
+        with:
+          language: ${{ inputs.language }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": ".github",
-  "version": "0.0.0",
+  "version": "3.0.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": ".github",
-      "version": "0.0.0",
+      "version": "3.0.38",
       "license": "UNLICENSED",
       "devDependencies": {
         "@kie/act-js": "^2.2.1",


### PR DESCRIPTION
## Release Notes

* adds new options for `setup_env` action
  * npm-install, allows the action to setup Node without running an npm install
  * node-auth-token, adds a way to add an auth token directly 
* adds a new workflow for backend PR flows