### PR TITLE
APP-14422: Consume full output of artemis-run.json during e2e runs

### DIFF
--- a/.github/actions/frontend/runtime/e2e_prepare/README.md
+++ b/.github/actions/frontend/runtime/e2e_prepare/README.md
@@ -23,6 +23,7 @@ This action returns the following outputs:
 | `artemis_account_subdomain` | String | The account subdomain extracted from the artemis-run.json file |
 | `artemis_account_id`        | String | The id extracted from the artemis-run.json file                |
 | `artemis_users`             | String | The users extracted from the artemis-run.json file             |
+| `artemis_full_output`       | String | The full output of the artemis-run.json file                   |
 
 ## Example Usage
 
@@ -39,5 +40,6 @@ steps:
       echo ${{ steps.e2e_prepare.outputs.artemis_account_subdomain }}
       echo ${{ steps.e2e_prepare.outputs.artemis_account_id }}
       echo ${{ steps.e2e_prepare.outputs.artemis_users }}
+      echo ${{ steps.e2e_prepare.outputs.artemis_full_output }}
     shell: bash
 ```

--- a/.github/actions/frontend/runtime/e2e_prepare/action.yml
+++ b/.github/actions/frontend/runtime/e2e_prepare/action.yml
@@ -17,6 +17,8 @@ outputs:
     value: ${{ steps.artemis_info.outputs.artemis_account_id }}
   artemis_users:
     value: ${{ steps.artemis_info.outputs.artemis_users }}
+  artemis_full_output:
+    value: ${{ steps.artemis_info.outputs.artemis_full_output }}
 
 runs:
   using: 'composite'
@@ -53,3 +55,4 @@ runs:
         echo "artemis_account_subdomain=$(jq -r .[0].metadata.accountSubdomain < artemis-run.json)" >> $GITHUB_OUTPUT
         echo "artemis_account_id=$(jq -r .[0].id < artemis-run.json)" >> $GITHUB_OUTPUT
         echo "artemis_users=$(jq -c 'map((select(. | .type == "User")) | { tokenSecret: .metadata.token.tokenSecret, tokenCsrf: .metadata.token.tokenCsrf, groupName: .metadata.groupName })' < artemis-run.json)" >> $GITHUB_OUTPUT
+        echo "artemis_full_output=`cat artemis-run.json`" >> $GITHUB_OUTPUT

--- a/.github/actions/frontend/runtime/e2e_prepare/action.yml
+++ b/.github/actions/frontend/runtime/e2e_prepare/action.yml
@@ -55,4 +55,4 @@ runs:
         echo "artemis_account_subdomain=$(jq -r .[0].metadata.accountSubdomain < artemis-run.json)" >> $GITHUB_OUTPUT
         echo "artemis_account_id=$(jq -r .[0].id < artemis-run.json)" >> $GITHUB_OUTPUT
         echo "artemis_users=$(jq -c 'map((select(. | .type == "User")) | { tokenSecret: .metadata.token.tokenSecret, tokenCsrf: .metadata.token.tokenCsrf, groupName: .metadata.groupName })' < artemis-run.json)" >> $GITHUB_OUTPUT
-        echo "artemis_full_output=`cat artemis-run.json`" >> $GITHUB_OUTPUT
+        echo "artemis_full_output=$(jq -c . < artemis-run.json)" >> $GITHUB_OUTPUT

--- a/.github/actions/frontend/runtime/e2e_prepare/test/action.test.ts
+++ b/.github/actions/frontend/runtime/e2e_prepare/test/action.test.ts
@@ -56,6 +56,10 @@ test('output of artemis_info returns correct results based off artemis-run.json'
     results,
     name: 'results_artemis_users',
   });
+  const results_artemis_full_output = getTestResult({
+    results,
+    name: 'results_artemis_full_output',
+  });
 
   expect(results_artemis_account_name.output).toEqual(
     artemisRun[0].metadata.accountName
@@ -72,5 +76,8 @@ test('output of artemis_info returns correct results based off artemis-run.json'
   );
   expect(results_artemis_users.output).toContain(
     artemisRun[1].metadata.groupName
+  );
+  expect(results_artemis_full_output.output).toEqual(
+    JSON.stringify(artemisRun)
   );
 });

--- a/.github/actions/frontend/runtime/e2e_prepare/test/action.test.ts
+++ b/.github/actions/frontend/runtime/e2e_prepare/test/action.test.ts
@@ -77,7 +77,10 @@ test('output of artemis_info returns correct results based off artemis-run.json'
   expect(results_artemis_users.output).toContain(
     artemisRun[1].metadata.groupName
   );
-  expect(results_artemis_full_output.output).toEqual(
-    JSON.stringify(artemisRun)
+  expect(results_artemis_full_output.output).toContain(
+    artemisRun[0].metadata.accountName
+  );
+  expect(results_artemis_full_output.output).toContain(
+    artemisRun[1].metadata.token.tokenSecret
   );
 });

--- a/.github/actions/frontend/runtime/e2e_prepare/test/action_test.yml
+++ b/.github/actions/frontend/runtime/e2e_prepare/test/action_test.yml
@@ -23,3 +23,6 @@ jobs:
       - name: results_artemis_users
         run: echo ${{ steps.e2e_prepare.outputs.artemis_users }}
         shell: bash
+      - name: results_artemis_full_output
+        run: echo ${{ steps.e2e_prepare.outputs.artemis_full_output }}
+        shell: bash

--- a/.github/actions/frontend/runtime/e2e_run/README.md
+++ b/.github/actions/frontend/runtime/e2e_run/README.md
@@ -13,6 +13,7 @@ This action takes the following inputs:
 | `artemis_account_subdomain`  | String |                                    | True     | The account subdomain extracted from the artemis-run.json file                                                                                                                |
 | `artemis_account_id`         | String |                                    | True     | The id extracted from the artemis-run.json file                                                                                                                               |
 | `artemis_users`              | String |                                    | True     | The users extracted from the artemis-run.json file                                                                                                                            |
+| `artemis_full_output`        | String |                                    | True     | The full output of the artemis-run.json file                                                                                                                                  |
 | `commit_info_sha`            | String | github.sha                         | True     | The sha associated with the PR that triggered the e2e_run                                                                                                                     |
 | `commit_info_pr_number`      | String | github.event.pull_request.number   | True     | The PR number associated with the PR that triggered the e2e_run                                                                                                               |
 | `commit_info_pr_title`       | String | github.event.pull_request.title    | True     | The PR title associated with the PR that triggered the e2e_run                                                                                                                |
@@ -53,6 +54,7 @@ steps:
       artemis_account_subdomain:
         ${{ needs.e2e_prepare.outputs.artemis_account_subdomain }}
       artemis_users: ${{ needs.e2e_prepare.outputs.artemis_users }}
+      artemis_full_output: ${{ needs.e2e_prepare.outputs.artemis_full_output }}
       cypress_container: ${{ matrix.containers }}
       cypress_tag: ${{ github.event.repository.name }},${{ github.event_name }}
       cypress_mailinator_api_key: ${{ secrets.CYPRESS_MAILINATOR_API_KEY }}

--- a/.github/actions/frontend/runtime/e2e_run/action.yml
+++ b/.github/actions/frontend/runtime/e2e_run/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: 'The users extracted from the artemis-run.json file'
     type: string
     required: true
+  artemis_full_output:
+    description: 'The full output of the artemis-run.json file'
+    type: string
+    required: true
   commit_info_sha:
     description:
       'The commit sha associated with the repo that triggered the e2e_run'
@@ -110,6 +114,7 @@ runs:
         echo "artemis_account_id=${{ inputs.artemis_account_id }}"
         echo "artemis_account_subdomain=${{ inputs.artemis_account_subdomain }}"
         echo "artemis_users=${{ inputs.artemis_users }}"
+        echo "artemis_full_output=${{ inputs.artemis_full_output }}"
         echo "commit_info_sha=${{ inputs.commit_info_sha }}"
         echo "commit_info_pr_number=${{ inputs.commit_info_pr_number }}"
         echo "commit_info_pr_title=${{ inputs.commit_info_pr_title }}"
@@ -164,6 +169,7 @@ runs:
         CYPRESS_PROJECT_ID: ${{ inputs.cypress_project_id }}
         CYPRESS_PASSWORD: ${{ inputs.cypress_password }}
         CYPRESS_ENVIRONMENT_NAME: jupiterone-dev
+        CYPRESS_ARTEMIS_OUTPUT: ${{ inputs.artemis_full_output }}
         GITHUB_TOKEN: ${{ inputs.github_token }}
         MIGRATION_NUMBER: ${{ inputs.migration_number }}
         PR_NUMBER: ${{ inputs.commit_info_pr_number }}

--- a/.github/workflows/frontend_runtime_application_manual_e2e_run.yml
+++ b/.github/workflows/frontend_runtime_application_manual_e2e_run.yml
@@ -153,6 +153,7 @@ jobs:
       artemis_account_subdomain:
         ${{ steps.e2e_prepare.outputs.artemis_account_subdomain }}
       artemis_users: ${{ steps.e2e_prepare.outputs.artemis_users }}
+      artemis_full_output: ${{ steps.e2e_prepare.outputs.artemis_full_output }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -228,6 +229,8 @@ jobs:
           artemis_account_subdomain:
             ${{ needs.e2e_prepare.outputs.artemis_account_subdomain }}
           artemis_users: ${{ needs.e2e_prepare.outputs.artemis_users }}
+          artemis_full_output:
+            ${{ needs.e2e_prepare.outputs.artemis_full_output }}
           cypress_container: ${{ matrix.containers }}
           cypress_mailinator_api_key: ${{ secrets.CYPRESS_MAILINATOR_API_KEY }}
           cypress_record_key: ${{ secrets.CYPRESS_RECORD_KEY }}

--- a/.github/workflows/frontend_runtime_e2e_trigger_response.yml
+++ b/.github/workflows/frontend_runtime_e2e_trigger_response.yml
@@ -108,6 +108,7 @@ jobs:
       artemis_account_subdomain:
         ${{ steps.e2e_prepare.outputs.artemis_account_subdomain }}
       artemis_users: ${{ steps.e2e_prepare.outputs.artemis_users }}
+      aremis_full_output: ${{ steps.e2e_prepare.outputs.aremis_full_output }}
     steps:
       - uses: actions/checkout@v3
       - name: setup_env
@@ -171,6 +172,8 @@ jobs:
           artemis_account_subdomain:
             ${{ needs.e2e_prepare.outputs.artemis_account_subdomain }}
           artemis_users: ${{ needs.e2e_prepare.outputs.artemis_users }}
+          artemis_full_output:
+            ${{ needs.e2e_prepare.outputs.artemis_full_output }}
           cypress_record_key: ${{ secrets.CYPRESS_RECORD_KEY }}
           cypress_project_id: ${{ secrets.CYPRESS_PROJECT_ID }}
           cypress_password: ${{ secrets.CYPRESS_PASSWORD }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": ".github",
-  "version": "3.0.38",
+  "version": "3.0.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": ".github",
-      "version": "3.0.38",
+      "version": "3.0.43",
       "license": "UNLICENSED",
       "devDependencies": {
         "@kie/act-js": "^2.2.1",


### PR DESCRIPTION
APP-14422: Add full output of artemis-run.json file as out put from `e2e_prepare` to be consumed in `e2e_run`.

Although we are exporting the full json output, I am not too worried about size of the variable here as we are using persistent accounts for e2e tests. Persistent accounts create most of their resources during the first run when a developer creates the artemis account locally on their machine, and not during an e2e run.