### PR TITLE
APP-14422: Wrap json output in quotes.

### DIFF
--- a/.github/actions/frontend/runtime/e2e_prepare/action.yml
+++ b/.github/actions/frontend/runtime/e2e_prepare/action.yml
@@ -55,4 +55,4 @@ runs:
         echo "artemis_account_subdomain=$(jq -r .[0].metadata.accountSubdomain < artemis-run.json)" >> $GITHUB_OUTPUT
         echo "artemis_account_id=$(jq -r .[0].id < artemis-run.json)" >> $GITHUB_OUTPUT
         echo "artemis_users=$(jq -c 'map((select(. | .type == "User")) | { tokenSecret: .metadata.token.tokenSecret, tokenCsrf: .metadata.token.tokenCsrf, groupName: .metadata.groupName })' < artemis-run.json)" >> $GITHUB_OUTPUT
-        echo "artemis_full_output=$(jq -c . < artemis-run.json)" >> $GITHUB_OUTPUT
+        echo "artemis_full_output='$(jq -c . < artemis-run.json)'" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Getting the following error in CI: 

```
Run jupiterone/.github/.github/actions/frontend/runtime/e2e_run@v3.0.44
Run echo "ci_build_id=sha-2e67654a88b68d1307ca4a74a56e[26](https://github.com/JupiterOne/web-insights/actions/runs/7807995710/job/21297586237#step:5:27)209b5fd7d3-time-1707265442"
/__w/_temp/28b2ff98-31a4-4d8d-a894-46c8e5a37916.sh: line 6: syntax error near unexpected token `('
ci_build_id=sha-2e67654a88b68d1307ca4a74a56e26209b5fd7d3-time-1707265442
artemis_account_name=null
artemis_account_id=artemis-cfe79820-4f13-57de-bb74-3b9528168c59
artemis_account_subdomain=null
artemis_users=[{tokenSecret:f2e83556bca4e6b7086e9105df1d41b49aa640a7f57686e1af3137303732363[53](https://github.com/JupiterOne/web-insights/actions/runs/7807995710/job/21297586237#step:5:55)63536383938,tokenCsrf:csrf-9aa444b9271ff44484d5819392dc0acbbe3d14435057b33[54](https://github.com/JupiterOne/web-insights/actions/runs/7807995710/job/21297586237#step:5:56)c31373037323635363536383938,groupName:artemis-group-0}]
Error: Process completed with exit code 2.
```

Link: https://github.com/JupiterOne/web-insights/actions/runs/7807995710/job/21297586237

The last command works fine locally. And we are reading the same json that we are reading on the previous lines:

```
echo "artemis_account_name=$(jq -r .[0].metadata.accountName < artemis-run.json)" >> $GITHUB_OUTPUT
echo "artemis_account_subdomain=$(jq -r .[0].metadata.accountSubdomain < artemis-run.json)" >> $GITHUB_OUTPUT
echo "artemis_account_id=$(jq -r .[0].id < artemis-run.json)" >> $GITHUB_OUTPUT
echo "artemis_users=$(jq -c 'map((select(. | .type == "User")) | { tokenSecret: .metadata.token.tokenSecret, tokenCsrf: .metadata.token.tokenCsrf, groupName: .metadata.groupName })' < artemis-run.json)" >> $GITHUB_OUTPUT
echo "artemis_full_output='$(jq -c . < artemis-run.json)"' >> $GITHUB_OUTPUT
```

# Fix
Hoping wrapping in quotes works, if not, I will have another PR to revert the changes and get e2e pipelines back up. I actually need the quotes to read the env variable in CI.