### PR TITLE
SRE-1723

### DIFF
--- a/.github/actions/frontend/runtime/e2e_prepare/action.yml
+++ b/.github/actions/frontend/runtime/e2e_prepare/action.yml
@@ -53,3 +53,7 @@ runs:
         echo "artemis_account_subdomain=$(jq -r .[0].metadata.accountSubdomain < artemis-run.json)" >> $GITHUB_OUTPUT
         echo "artemis_account_id=$(jq -r .[0].id < artemis-run.json)" >> $GITHUB_OUTPUT
         echo "artemis_users=$(jq -c 'map((select(. | .type == "User")) | { tokenSecret: .metadata.token.tokenSecret, tokenCsrf: .metadata.token.tokenCsrf, groupName: .metadata.groupName })' < artemis-run.json)" >> $GITHUB_OUTPUT
+    - uses: actions/upload-artifact@v4
+      with:
+        name: artemis-run
+        path: artemis-run.json

--- a/.github/actions/frontend/runtime/e2e_prepare/action.yml
+++ b/.github/actions/frontend/runtime/e2e_prepare/action.yml
@@ -54,6 +54,7 @@ runs:
         echo "artemis_account_id=$(jq -r .[0].id < artemis-run.json)" >> $GITHUB_OUTPUT
         echo "artemis_users=$(jq -c 'map((select(. | .type == "User")) | { tokenSecret: .metadata.token.tokenSecret, tokenCsrf: .metadata.token.tokenCsrf, groupName: .metadata.groupName })' < artemis-run.json)" >> $GITHUB_OUTPUT
     - uses: actions/upload-artifact@v4
+      name: upload_artemis_run
       with:
         name: artemis-run
         path: artemis-run.json

--- a/.github/actions/frontend/runtime/e2e_prepare/mocks.ts
+++ b/.github/actions/frontend/runtime/e2e_prepare/mocks.ts
@@ -7,4 +7,5 @@ export const E2E_PREPARE_MOCK_STEPS = [
   { name: 'configure_aws_credentials' },
   { name: 'update_artemis_config' },
   { name: 'launch_artemis' },
+  { name: 'upload_artemis_run' }
 ];

--- a/.github/actions/frontend/runtime/e2e_run/action.yml
+++ b/.github/actions/frontend/runtime/e2e_run/action.yml
@@ -131,7 +131,8 @@ runs:
       shell: bash
       run:
         echo "commit_info_author=$(git show -s --pretty=%an)" >> $GITHUB_OUTPUT
-    - uses: actions/download-artifact@v4
+    - name: download_artemis_run
+      uses: actions/download-artifact@v4
       with:
         name: artemis-run
     - name: cypress_run

--- a/.github/actions/frontend/runtime/e2e_run/action.yml
+++ b/.github/actions/frontend/runtime/e2e_run/action.yml
@@ -131,6 +131,9 @@ runs:
       shell: bash
       run:
         echo "commit_info_author=$(git show -s --pretty=%an)" >> $GITHUB_OUTPUT
+    - uses: actions/download-artifact@v4
+      with:
+        name: artemis-run
     - name: cypress_run
       id: cypress_run
       continue-on-error: ${{ fromJSON(inputs.e2e_pass_on_error) }}

--- a/.github/actions/frontend/runtime/e2e_run/mocks.ts
+++ b/.github/actions/frontend/runtime/e2e_run/mocks.ts
@@ -6,4 +6,5 @@ mocked, they would break the test.
 export const E2E_RUN_MOCK_STEPS = [
   { name: 'get_author_name' },
   { name: 'cypress_run' },
+  { name: 'download_artemis_run' },
 ];


### PR DESCRIPTION
# Overview

As [shown here](https://github.com/JupiterOne/web-alerts/pull/429/files#diff-cc2b18f9506031aa41b725ac70f183547fd9752537380729fb3151d876ec8357R4), these updates will make the `artemis-run.json` file available so cypress can read the file in while running tests in CI.

The following command can be run for both local and CI tests as the `artemis-run` file will always be placed at the root of the project:

```
cy.readFile('artemis-run.json').then((jsonData) => {
    cy.log(jsonData);
});
```

# Testing

As shown in the [following cypress run](https://cloud.cypress.io/projects/1bn4a8/runs/457/overview/8f7c8c92-374e-485f-ad8d-12b318fef330/video?roarHideRunsWithDiffGroupsAndTags=1), you can see the file getting loaded in and the results logged out (note: forced a failure so we could see the log results):

<img width="422" alt="Screenshot 2024-02-20 at 2 43 05 PM" src="https://github.com/JupiterOne/.github/assets/1964654/9ad27a7d-a9f1-4d22-a059-a961f14fa413">

