### PR TITLE
SRE-1782

### DIFF
--- a/.github/actions/frontend/runtime/e2e_trigger_remote_tests/action.yml
+++ b/.github/actions/frontend/runtime/e2e_trigger_remote_tests/action.yml
@@ -51,8 +51,8 @@ runs:
         propagate_failure: ${{ !fromJSON(inputs.e2e_pass_on_error) }}
         client_payload:
           '{"spec_to_run":"${{ inputs.repo_spec }}","external_pr_number":"${{
-          github.event.issue.number }}","external_pr_title":"${{
-          github.event.issue.title }}","external_pr_repo_name":"${{
+          github.event.issue.number }}","external_pr_title":${{
+          toJSON(github.event.issue.title) }},"external_pr_repo_name":"${{
           github.event.repository.name }}","external_pr_branch":"${{
           inputs.pr_branch }}","external_pr_author":"${{
           steps.get_author_name.outputs.commit_info_author

--- a/.github/workflows/e2e_trigger.yml
+++ b/.github/workflows/e2e_trigger.yml
@@ -81,8 +81,8 @@ jobs:
           client_payload:
             '{"spec_to_run":"${{ matrix.repos.repo.spec
             }}","external_pr_number":"${{ github.event.pull_request.number
-            }}","external_pr_title":"${{ github.event.pull_request.title
-            }}","external_pr_repo_name":"${{ github.event.repository.name
+            }}","external_pr_title":${{ toJSON(github.event.pull_request.title)
+            }},"external_pr_repo_name":"${{ github.event.repository.name
             }}","external_pr_branch":"${{ github.event.pull_request.head.ref
             }}","external_pr_author":"${{ env.COMMIT_INFO_AUTHOR
             }}","external_pr_sha":"${{ github.event.pull_request.base.sha }}"}'


### PR DESCRIPTION
# Overview

The `client_payload` input that is passed along as a part of the `trigger-workflow-and-wait` action uses the PR title as a parameter without escaping it.  If the title has double quotes (ex. `"SRE-1782 - Test PR title with "double quotes""`), it will cause the json to be invalid and cause tests to fail. To address this, we simply need to wrap the parameter in a `toJSON` expression which will escape the quotes as shown here:

<img width="472" alt="Screenshot 2024-03-14 at 3 13 47 PM" src="https://github.com/JupiterOne/.github/assets/1964654/e0321b14-502a-4455-93e2-8eb25983d5dd">

# Testing

This was tested in `web-dashboards` using local actions.